### PR TITLE
Replacing System.out.print with logger ("Database name is: "...)

### DIFF
--- a/engine/data/score-data-api/src/main/java/io/cloudslang/engine/dialects/ScoreDialectResolver.java
+++ b/engine/data/score-data-api/src/main/java/io/cloudslang/engine/dialects/ScoreDialectResolver.java
@@ -10,6 +10,7 @@
 
 package io.cloudslang.engine.dialects;
 
+import org.apache.log4j.Logger;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.service.jdbc.dialect.internal.StandardDialectResolver;
 
@@ -24,11 +25,15 @@ import java.sql.SQLException;
  */
 public class ScoreDialectResolver  extends StandardDialectResolver {
 
+    private final Logger logger = Logger.getLogger(getClass());
+
     @Override
     protected Dialect resolveDialectInternal(DatabaseMetaData metaData) throws SQLException {
         String databaseName = metaData.getDatabaseProductName();
         int databaseMajorVersion = metaData.getDatabaseMajorVersion();
-        System.out.println("Database name is: " + databaseName + " databaseMajorVersion is: " + databaseMajorVersion);
+
+        logger.info("Database name is: " + databaseName + " databaseMajorVersion is: " + databaseMajorVersion);
+        
         if ( "MySQL".equals( databaseName ) ) {
 			return new ScoreMySQLDialect();
         }


### PR DESCRIPTION
Fixes CloudSlang/cloud-slang#242
Signed-off-by: Meir Wahnon <meir.wahnon@hp.com>