### PR TITLE
Update metadata during running execution plan change

### DIFF
--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ScoreTriggeringImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ScoreTriggeringImpl.java
@@ -19,11 +19,13 @@ import io.cloudslang.engine.queue.entities.ExecutionMessage;
 import io.cloudslang.engine.queue.entities.ExecutionMessageConverter;
 import io.cloudslang.engine.queue.entities.Payload;
 import io.cloudslang.engine.queue.services.QueueDispatcherService;
+import io.cloudslang.score.api.execution.ExecutionMetadataConsts;
 import io.cloudslang.score.facade.entities.Execution;
 import io.cloudslang.score.facade.services.RunningExecutionPlanService;
 import io.cloudslang.score.lang.SystemContext;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,7 +63,8 @@ public class ScoreTriggeringImpl implements ScoreTriggering {
         SystemContext scoreSystemContext = new SystemContext(triggeringProperties.getRuntimeValues());
         Long runningExecutionPlanId = saveRunningExecutionPlans(triggeringProperties.getExecutionPlan(), triggeringProperties.getDependencies(), scoreSystemContext);
         scoreSystemContext.setExecutionId(executionId);
-        scoreSystemContext.putMetaData(triggeringProperties.getMetadata());
+        Map<String,Serializable> executionMetadata = createMetadata(triggeringProperties);
+        scoreSystemContext.putMetaData(executionMetadata);
         Execution execution = new Execution(executionId, runningExecutionPlanId, triggeringProperties.getStartStep(), triggeringProperties.getContext(), scoreSystemContext);
 
         // create execution record in ExecutionSummary table
@@ -71,6 +74,20 @@ public class ScoreTriggeringImpl implements ScoreTriggering {
         ExecutionMessage message = createExecutionMessage(execution);
         enqueue(message);
         return executionId;
+    }
+
+    private Map<String,Serializable> createMetadata(TriggeringProperties triggeringProperties){
+        Map<String,Serializable> executionMetadata = new HashMap<>();
+        ExecutionPlan executionPlan = triggeringProperties.getExecutionPlan();
+        executionMetadata.put(ExecutionMetadataConsts.EXECUTION_PLAN_ID, executionPlan.getFlowUuid());
+        executionMetadata.put(ExecutionMetadataConsts.EXECUTION_PLAN_NAME,executionPlan.getName());
+
+        Map<String,Serializable> platformMetadata = (Map<String,Serializable>)triggeringProperties.getPlatformMetadata();
+        if (platformMetadata != null){
+            executionMetadata.putAll(platformMetadata);
+        }
+
+        return executionMetadata;
     }
 
     private Long saveRunningExecutionPlans(ExecutionPlan executionPlan, Map<String, ExecutionPlan> dependencies, SystemContext systemContext) {

--- a/score-api/src/main/java/io/cloudslang/score/api/TriggeringProperties.java
+++ b/score-api/src/main/java/io/cloudslang/score/api/TriggeringProperties.java
@@ -25,7 +25,7 @@ public class TriggeringProperties {
     private Map<String, ExecutionPlan> dependencies = new HashMap<>();
     private Map<String, ? extends Serializable> context = new HashMap<>();
     private Map<String, ? extends Serializable> runtimeValues = new HashMap<>();
-    private Map<String, ? extends Serializable> metadata = new HashMap<>();
+    private Map<String, ? extends Serializable> platformMetadata = new HashMap<>();
     private Long startStep;
 
     private TriggeringProperties(ExecutionPlan executionPlan){
@@ -57,8 +57,12 @@ public class TriggeringProperties {
         return this;
     }
 
-    public TriggeringProperties setMetadata(Map<String, ? extends Serializable> metadata) {
-        this.metadata = metadata;
+    public Map<String, ? extends Serializable> getPlatformMetadata() {
+        return platformMetadata;
+    }
+
+    public TriggeringProperties setPlatformMetadata(Map<String, ? extends Serializable> platformMetadata) {
+        this.platformMetadata = platformMetadata;
         return this;
     }
 
@@ -78,11 +82,9 @@ public class TriggeringProperties {
         return runtimeValues;
     }
 
+
     public Long getStartStep() {
         return startStep;
     }
 
-    public Map<String, ? extends Serializable> getMetadata() {
-        return metadata;
-    }
 }

--- a/score-api/src/main/java/io/cloudslang/score/api/execution/ExecutionMetadataConsts.java
+++ b/score-api/src/main/java/io/cloudslang/score/api/execution/ExecutionMetadataConsts.java
@@ -7,5 +7,5 @@ public class ExecutionMetadataConsts {
 
     public static final String EXECUTION_PLAN_ID = "EXECUTION_PLAN_ID";
     public static final String EXECUTION_PLAN_NAME = "EXECUTION_PLAN_NAME";
-    public static final String RUNNING_USER = "RUNNING_USER";
+
 }

--- a/score-api/src/main/java/io/cloudslang/score/api/execution/ExecutionMetadataConsts.java
+++ b/score-api/src/main/java/io/cloudslang/score/api/execution/ExecutionMetadataConsts.java
@@ -1,0 +1,11 @@
+package io.cloudslang.score.api.execution;
+
+/**
+ * Created by varelase on 24/06/2015.
+ */
+public class ExecutionMetadataConsts {
+
+    public static final String EXECUTION_PLAN_ID = "EXECUTION_PLAN_ID";
+    public static final String EXECUTION_PLAN_NAME = "EXECUTION_PLAN_NAME";
+    public static final String RUNNING_USER = "RUNNING_USER";
+}

--- a/worker/worker-execution/score-worker-execution-impl/src/main/java/io/cloudslang/worker/execution/services/ExecutionServiceImpl.java
+++ b/worker/worker-execution/score-worker-execution-impl/src/main/java/io/cloudslang/worker/execution/services/ExecutionServiceImpl.java
@@ -10,8 +10,10 @@
 
 package io.cloudslang.worker.execution.services;
 
+import io.cloudslang.score.api.ExecutionPlan;
 import io.cloudslang.score.api.ExecutionStep;
 import io.cloudslang.score.api.StartBranchDataContainer;
+import io.cloudslang.score.api.execution.ExecutionMetadataConsts;
 import io.cloudslang.score.api.execution.ExecutionParametersConsts;
 import io.cloudslang.score.events.EventBus;
 import io.cloudslang.score.events.EventConstants;
@@ -296,6 +298,7 @@ public final class ExecutionServiceImpl implements ExecutionService {
 			if(position != null) {
 				runningExecutionPlan = workerDbSupportService.readExecutionPlanById(execution.getRunningExecutionPlanId());
 				if(runningExecutionPlan != null) {
+					updateMetadata(execution,runningExecutionPlan);
 					ExecutionStep currStep = runningExecutionPlan.getExecutionPlan().getStep(position);
 					if(logger.isDebugEnabled()) {
 						logger.debug("Begin step: " + position + " in flow " + runningExecutionPlan.getExecutionPlan().getFlowUuid() + " [" + execution.getExecutionId() + "]");
@@ -308,6 +311,13 @@ public final class ExecutionServiceImpl implements ExecutionService {
 		}
 		// If we got here - one of the objects was null
 		throw new RuntimeException("Failed to load ExecutionStep!");
+	}
+
+	private void updateMetadata(Execution execution, RunningExecutionPlan runningExecutionPlan){
+		Map<String,Serializable> executionMetadata = (Map<String,Serializable>)execution.getSystemContext().getMetaData();
+		ExecutionPlan executionPlan  = runningExecutionPlan.getExecutionPlan();
+		executionMetadata.put(ExecutionMetadataConsts.EXECUTION_PLAN_ID,executionPlan.getFlowUuid());
+		executionMetadata.put(ExecutionMetadataConsts.EXECUTION_PLAN_NAME,executionPlan.getName());
 	}
 
 	protected void executeStep(Execution execution, ExecutionStep currStep) {

--- a/worker/worker-execution/score-worker-execution-impl/src/test/java/io/cloudslang/worker/execution/services/ExecutionServiceTest.java
+++ b/worker/worker-execution/score-worker-execution-impl/src/test/java/io/cloudslang/worker/execution/services/ExecutionServiceTest.java
@@ -173,7 +173,8 @@ public class ExecutionServiceTest {
 		Execution exe = new Execution(EXECUTION_ID_1,0L, 0L, new HashMap<String,String>(), null);
 
 		exe.getSystemContext().put(TempConstants.CONTENT_EXECUTION_STEP, executionStep);
-
+		Map<String,Serializable> metadata = new HashMap<>();
+		exe.getSystemContext().putMetaData(metadata);
 		ExecutionStep loadedStep = executionService.loadExecutionStep(exe);
 
 		Assert.assertEquals(executionStep.getExecStepId(), loadedStep.getExecStepId());
@@ -190,7 +191,7 @@ public class ExecutionServiceTest {
 		executionStep = new ExecutionStep(EXECUTION_STEP_2_ID);
 
 		exe = new Execution(RUNNING_EXE_PLAN_ID, EXECUTION_STEP_2_ID, new HashMap<String,String>());
-
+		exe.getSystemContext().putMetaData(metadata);
 		loadedStep = executionService.loadExecutionStep(exe);
 
 		Assert.assertEquals(executionStep.getExecStepId(), loadedStep.getExecStepId());


### PR DESCRIPTION
fix cloudslang/cloud-slang#340

The score engine will replace the execution plan name & id values on the ExecutionRuntimeServices metadata map when replacing the execution plan