### PR TITLE
Load config value from Java system properties first, then from the xml

### DIFF
--- a/package/score-worker/src/main/java/io/cloudslang/schema/ConfValue.java
+++ b/package/score-worker/src/main/java/io/cloudslang/schema/ConfValue.java
@@ -50,6 +50,10 @@ class ConfValue {
 	}
 
 	private Object fromString(String value) {
+		String sysValue = System.getProperty("cloudslang.worker." + name);
+		if(sysValue != null) {
+			value = sysValue;
+		}
 		if (StringUtils.hasText(value)){
 			try {
 				return clazz.getConstructor(String.class).newInstance(value);

--- a/package/score-worker/src/main/java/io/cloudslang/schema/ConfValue.java
+++ b/package/score-worker/src/main/java/io/cloudslang/schema/ConfValue.java
@@ -50,10 +50,7 @@ class ConfValue {
 	}
 
 	private Object fromString(String value) {
-		String sysValue = System.getProperty("cloudslang.worker." + name);
-		if(sysValue != null) {
-			value = sysValue;
-		}
+		value = System.getProperty("cloudslang.worker." + name, value);
 		if (StringUtils.hasText(value)){
 			try {
 				return clazz.getConstructor(String.class).newInstance(value);


### PR DESCRIPTION
Now config values like numberOfExecutionThreads, inBufferCapacity can be provided as system properties cloudslang.worker.numberOfExecutionThreads, cloudslang.worker.inBufferCapacity