### PR TITLE
Worker version support

### DIFF
--- a/engine/data/score-data-api/src/main/resources/META-INF/database/score.changes.xml
+++ b/engine/data/score-data-api/src/main/resources/META-INF/database/score.changes.xml
@@ -254,6 +254,7 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
             <column name="IS_DELETED" type="boolean" valueBoolean="false" />
             <column name="BULK_NUMBER" type="VARCHAR(48)"/>
             <column name="WRV" type="VARCHAR(48)"/>
+            <column name="VERSION" type="VARCHAR(48)"/>
         </createTable>
 
         <createTable tableName="OO_WORKER_GROUPS">

--- a/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/entities/Worker.java
+++ b/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/entities/Worker.java
@@ -41,4 +41,6 @@ public interface Worker {
 	List<String> getGroups();
 
     boolean isDeleted();
+
+	String getVersion();
 }

--- a/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/entities/WorkerNode.java
+++ b/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/entities/WorkerNode.java
@@ -106,7 +106,7 @@ public class WorkerNode extends AbstractIdentifiable implements Worker {
     private String workerRecoveryVersion;
 
 	@Column(name = "VERSION", length = 48, nullable = false)
-	private String version = "N/A";
+	private String version = "";
 
     @Override
 	public String getUuid() {

--- a/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/entities/WorkerNode.java
+++ b/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/entities/WorkerNode.java
@@ -105,6 +105,9 @@ public class WorkerNode extends AbstractIdentifiable implements Worker {
     @Column(name = "WRV", length = 48)
     private String workerRecoveryVersion;
 
+	@Column(name = "VERSION", length = 48, nullable = false)
+	private String version = "N/A";
+
     @Override
 	public String getUuid() {
 		return uuid;
@@ -244,52 +247,84 @@ public class WorkerNode extends AbstractIdentifiable implements Worker {
         this.workerRecoveryVersion = workerRecoveryVersion;
     }
 
-    @Override
+	@Override
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (!(o instanceof WorkerNode)) return false;
+		if (o == null || getClass() != o.getClass()) return false;
 
 		WorkerNode that = (WorkerNode) o;
 
-		return new EqualsBuilder()
-				.append(this.uuid, that.uuid)
-				.append(this.description, that.description)
-				.append(this.hostName, that.hostName)
-				.append(this.installPath, that.installPath)
-				.append(this.active, that.active)
-				.append(this.ackTime, that.ackTime)
-                .append(this.ackVersion, that.ackVersion)
-				.append(this.os, that.os)
-				.append(this.jvm, that.jvm)
-				.append(this.dotNetVersion, that.dotNetVersion)
-				.append(this.groups, that.groups)
-                .append(this.bulkNumber, that.bulkNumber)
-                .append(this.workerRecoveryVersion, that.workerRecoveryVersion)
-				.isEquals();
+		if (active != that.active) return false;
+		if (deleted != that.deleted) return false;
+		if (ackVersion != that.ackVersion) return false;
+		if (uuid != null ? !uuid.equals(that.uuid) : that.uuid != null) return false;
+		if (status != that.status) return false;
+		if (hostName != null ? !hostName.equals(that.hostName) : that.hostName != null) return false;
+		if (installPath != null ? !installPath.equals(that.installPath) : that.installPath != null) return false;
+		if (description != null ? !description.equals(that.description) : that.description != null) return false;
+		if (password != null ? !password.equals(that.password) : that.password != null) return false;
+		if (os != null ? !os.equals(that.os) : that.os != null) return false;
+		if (jvm != null ? !jvm.equals(that.jvm) : that.jvm != null) return false;
+		if (dotNetVersion != null ? !dotNetVersion.equals(that.dotNetVersion) : that.dotNetVersion != null) return false;
+		if (ackTime != null ? !ackTime.equals(that.ackTime) : that.ackTime != null) return false;
+		if (groups != null ? !groups.equals(that.groups) : that.groups != null) return false;
+		if (bulkNumber != null ? !bulkNumber.equals(that.bulkNumber) : that.bulkNumber != null) return false;
+		if (workerRecoveryVersion != null ? !workerRecoveryVersion.equals(that.workerRecoveryVersion) : that.workerRecoveryVersion != null) return false;
+		return !(version != null ? !version.equals(that.version) : that.version != null);
+
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(uuid,description,hostName,installPath,active,ackVersion,ackTime,os,jvm,dotNetVersion,groups,bulkNumber,workerRecoveryVersion);
+		int result = uuid != null ? uuid.hashCode() : 0;
+		result = 31 * result + (status != null ? status.hashCode() : 0);
+		result = 31 * result + (active ? 1 : 0);
+		result = 31 * result + (hostName != null ? hostName.hashCode() : 0);
+		result = 31 * result + (installPath != null ? installPath.hashCode() : 0);
+		result = 31 * result + (description != null ? description.hashCode() : 0);
+		result = 31 * result + (password != null ? password.hashCode() : 0);
+		result = 31 * result + (os != null ? os.hashCode() : 0);
+		result = 31 * result + (jvm != null ? jvm.hashCode() : 0);
+		result = 31 * result + (dotNetVersion != null ? dotNetVersion.hashCode() : 0);
+		result = 31 * result + (ackTime != null ? ackTime.hashCode() : 0);
+		result = 31 * result + (deleted ? 1 : 0);
+		result = 31 * result + (int) (ackVersion ^ (ackVersion >>> 32));
+		result = 31 * result + (groups != null ? groups.hashCode() : 0);
+		result = 31 * result + (bulkNumber != null ? bulkNumber.hashCode() : 0);
+		result = 31 * result + (workerRecoveryVersion != null ? workerRecoveryVersion.hashCode() : 0);
+		result = 31 * result + (version != null ? version.hashCode() : 0);
+		return result;
 	}
 
 	@Override
 	public String toString() {
-
-		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-				.append("UUID", uuid)
-				.append("active", active)
-				.append("ackTime", ackTime)
-                .append("ackVersion", ackVersion)
-				.append("host", hostName)
-				.append("path", installPath)
-				.append("OS", os)
-				.append("JVM", jvm)
-				.append(".NET", dotNetVersion)
-				.append("groups", groups)
-                .append("bulkNumber", bulkNumber)
-                .append("workerRecoveryVersion", workerRecoveryVersion)
-				.toString()
-		;
+		return "WorkerNode{" +
+				"uuid='" + uuid + '\'' +
+				", status=" + status +
+				", active=" + active +
+				", hostName='" + hostName + '\'' +
+				", installPath='" + installPath + '\'' +
+				", description='" + description + '\'' +
+				", password='" + password + '\'' +
+				", os='" + os + '\'' +
+				", jvm='" + jvm + '\'' +
+				", dotNetVersion='" + dotNetVersion + '\'' +
+				", ackTime=" + ackTime +
+				", deleted=" + deleted +
+				", ackVersion=" + ackVersion +
+				", groups=" + groups +
+				", bulkNumber='" + bulkNumber + '\'' +
+				", workerRecoveryVersion='" + workerRecoveryVersion + '\'' +
+				", version='" + version + '\'' +
+				'}';
 	}
 }

--- a/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/services/WorkerNodeService.java
+++ b/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/services/WorkerNodeService.java
@@ -244,4 +244,13 @@ public interface WorkerNodeService {
      * @return a List of String of the worker uuids
      */
     List<String> readAllWorkersUuids();
+
+    /**
+     *
+     * updates the worker version of a given worker
+     *
+     * @param workerUuid the uuid of the worker to update
+     * @param version the new worker recovery version
+     */
+    void updateVersion(String workerUuid, String version);
 }

--- a/engine/node/score-node-impl/src/main/java/io/cloudslang/engine/node/services/WorkerNodeServiceImpl.java
+++ b/engine/node/score-node-impl/src/main/java/io/cloudslang/engine/node/services/WorkerNodeServiceImpl.java
@@ -33,7 +33,7 @@ import java.util.List;
  * @since 11/11/2012
  * @version $Id$
  */
-public final class WorkerNodeServiceImpl implements WorkerNodeService {
+public class WorkerNodeServiceImpl implements WorkerNodeService {
 
 	private static final long maxVersionGapAllowed = Long.getLong("max.allowed.version.gap.worker.recovery", 2);
 	private static final String MSG_RECOVERY_VERSION_NAME = "MSG_RECOVERY_VERSION";
@@ -148,6 +148,16 @@ public final class WorkerNodeServiceImpl implements WorkerNodeService {
 			result.add(w.getUuid());
 		}
 		return result;
+	}
+
+	@Override
+	@Transactional
+	public void updateVersion(String workerUuid, String version) {
+		WorkerNode worker = workerNodeRepository.findByUuid(workerUuid);
+		if(worker == null) {
+			throw new IllegalStateException("No worker was found by the specified UUID:" + workerUuid);
+		}
+		worker.setVersion(version);
 	}
 
 	@Override

--- a/engine/node/score-node-impl/src/test/java/io/cloudslang/engine/node/services/WorkerNodeServiceTest.java
+++ b/engine/node/score-node-impl/src/test/java/io/cloudslang/engine/node/services/WorkerNodeServiceTest.java
@@ -288,7 +288,7 @@ public class WorkerNodeServiceTest {
 	public void updateVersionTest() {
 		workerNodeService.create("worker_1", "password", "stamHost", "c:/dir");
 		WorkerNode workerNode = workerNodeService.readByUUID("H1");
-		Assert.assertEquals("N/A", workerNode.getVersion());
+		Assert.assertEquals("", workerNode.getVersion());
 
 		workerNodeService.updateVersion("H1", "VERSION");
 

--- a/engine/node/score-node-impl/src/test/java/io/cloudslang/engine/node/services/WorkerNodeServiceTest.java
+++ b/engine/node/score-node-impl/src/test/java/io/cloudslang/engine/node/services/WorkerNodeServiceTest.java
@@ -88,7 +88,7 @@ public class WorkerNodeServiceTest {
 
     @After
     public void reset(){
-        Mockito.reset(versionService,workerLockService);
+        Mockito.reset(versionService, workerLockService);
     }
 	@Test
 	public void keepAlive() throws Exception {
@@ -233,7 +233,7 @@ public class WorkerNodeServiceTest {
 		WorkerNode worker = workerNodeService.readByUUID("H3");
 		Assert.assertEquals(WorkerStatus.FAILED, worker.getStatus());
 
-		workerNodeService.updateStatus("H3",WorkerStatus.RUNNING);
+		workerNodeService.updateStatus("H3", WorkerStatus.RUNNING);
 		worker = workerNodeService.readByUUID("H3");
 		Assert.assertEquals(WorkerStatus.RUNNING, worker.getStatus());
 	}
@@ -257,7 +257,7 @@ public class WorkerNodeServiceTest {
 		workerNodeService.updateWorkerGroups("H3", "group 1", "group 2");
 		workerNodeService.updateWorkerGroups("H1", "group 1");
 		groups = workerNodeService.readAllWorkerGroups();
-		Assert.assertEquals(WorkerNode.DEFAULT_WORKER_GROUPS.length+2, groups.size());
+		Assert.assertEquals(WorkerNode.DEFAULT_WORKER_GROUPS.length + 2, groups.size());
 
 		workerNodeService.updateWorkerGroups("H3");
 		WorkerNode workerNode = workerNodeService.readByUUID("H3");
@@ -282,6 +282,19 @@ public class WorkerNodeServiceTest {
 		workerNode = workerNodeService.readByUUID("H1");
 
 		Assert.assertEquals(groupSize+1, workerNode.getGroups().size());
+	}
+
+	@Test
+	public void updateVersionTest() {
+		workerNodeService.create("worker_1", "password", "stamHost", "c:/dir");
+		WorkerNode workerNode = workerNodeService.readByUUID("H1");
+		Assert.assertEquals("N/A", workerNode.getVersion());
+
+		workerNodeService.updateVersion("H1", "VERSION");
+
+		workerNode = workerNodeService.readByUUID("H1");
+
+		Assert.assertEquals("Version not updated!", "VERSION", workerNode.getVersion());
 	}
 
 	@Configuration

--- a/package/score-all/src/main/java/io/cloudslang/schema/EngineBeanDefinitionParser.java
+++ b/package/score-all/src/main/java/io/cloudslang/schema/EngineBeanDefinitionParser.java
@@ -81,7 +81,6 @@ public class EngineBeanDefinitionParser extends AbstractBeanDefinitionParser {
 		put(ExecutionAssignerServiceImpl.class, "executionAssignerService");
 		put(PartitionServiceImpl.class, null);
 		put(RunningExecutionPlanServiceImpl.class, "runningEP");
-		put(WorkerNodeServiceImpl.class, null);
 		put(VersionServiceImpl.class, null);
 		put(CancelExecutionServiceImpl.class, "cancelExecutionService");
 		put(ScoreEventFactoryImpl.class, "scoreEventFactory");
@@ -151,6 +150,7 @@ public class EngineBeanDefinitionParser extends AbstractBeanDefinitionParser {
 
     private void registerSpecialBeans(Element element, ParserContext parserContext) {
         registerPauseResume(element,parserContext);
+		registerWorkerNodeService(element, parserContext);
     }
 
     private void registerPauseResume(Element element, ParserContext parserContext){
@@ -159,6 +159,13 @@ public class EngineBeanDefinitionParser extends AbstractBeanDefinitionParser {
             new BeanRegistrator(parserContext).CLASS(StubPauseResumeServiceImpl.class).register();
         }
     }
+
+	private void registerWorkerNodeService(Element element, ParserContext parserContext){
+		String registerWorkerNodeService = element.getAttribute("registerWorkerNodeService");
+		if(!registerWorkerNodeService.equals(Boolean.FALSE.toString())){
+			new BeanRegistrator(parserContext).CLASS(WorkerNodeServiceImpl.class).register();
+		}
+	}
 
 	private void registerPartitionTemplate(String name, int groupSize, long sizeThreshold, long timeThreshold,
                                            ParserContext parserContext,

--- a/score-api/src/main/resources/io/cloudslang/schema/score.xsd
+++ b/score-api/src/main/resources/io/cloudslang/schema/score.xsd
@@ -21,6 +21,7 @@
             <xsd:attribute type="xsd:boolean" name="externalDatabase" />
             <xsd:attribute type="xsd:boolean" name="ignoreEngineJobs" />
             <xsd:attribute type="xsd:boolean" name="registerPauseResumeService"/>
+            <xsd:attribute type="xsd:boolean" name="registerWorkerNodeService"/>
         </xsd:complexType>
 	</xsd:element>
 


### PR DESCRIPTION
Signed-off-by: Natasha Beck <natasha.kravtsov@hp.com>

In order to support worker in cluster we need to have version for each worker.
In order to have correct execution all workers should have the same version.