### PR TITLE
Cover Canceling by interrupt execution with status pending-pause

### DIFF
--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/CancelExecutionServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/CancelExecutionServiceImpl.java
@@ -75,7 +75,7 @@ public final class CancelExecutionServiceImpl implements CancelExecutionService 
         // it's possible to cancel only running or paused executions.
         // If it's running - set to pending-cancel, and the ExecutionServiceImpl will handle it and extract it from the queue.
         // If it's paused - sometimes needs to handle its branches (if such exists).
-        if (status.equals(ExecutionStatus.RUNNING)) {
+        if (status.equals(ExecutionStatus.RUNNING)  || status.equals(ExecutionStatus.PENDING_PAUSE)) {
             executionStateToCancel.setStatus(ExecutionStatus.PENDING_CANCEL);
         } else if (status.equals(ExecutionStatus.PAUSED)) {
             cancelPausedRun(executionStateToCancel);

--- a/engine/orchestrator/score-orchestrator-impl/src/test/java/io/cloudslang/orchestrator/services/CancelExecutionServiceTest.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/test/java/io/cloudslang/orchestrator/services/CancelExecutionServiceTest.java
@@ -140,7 +140,6 @@ public class CancelExecutionServiceTest {
     @Test
     public void testInvalidRequestCancel() {
         checkInvalidRequestCancel(ExecutionStatus.COMPLETED, ExecutionActionResult.FAILED_ALREADY_COMPLETED);
-        checkInvalidRequestCancel(ExecutionStatus.PENDING_PAUSE, ExecutionActionResult.FAILED_PENDING_PAUSE);
         checkInvalidRequestCancel(ExecutionStatus.SYSTEM_FAILURE, ExecutionActionResult.FAILED_SYSTEM_FAILURE);
     }
 


### PR DESCRIPTION
Signed-off-by: Hajyhia Shehab shehab.hajyhia@hpe.com

Covering the status pending-pause by Cancel action will solve the cases were execution stack on pending-pause therefore, timeout will handle such executions and prevent them to be stacked for ever 

