### PR TITLE
Fix issue #75 : Adding worker more than once to the same workers grou…

### DIFF
--- a/engine/data/score-data-api/src/main/resources/META-INF/database/score.changes.xml
+++ b/engine/data/score-data-api/src/main/resources/META-INF/database/score.changes.xml
@@ -83,8 +83,7 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
 
     <!--The payload column is a blob in mysql it is not big enough-->
     <changeSet id="alter OO_EXECUTION_STATES PAYLOAD column" author="engine" dbms="mysql">
-        <sql>ALTER TABLE OO_EXECUTION_STATES_1 MODIFY PAYLOAD MEDIUMBLOB NOT NULL;</sql>
-        <sql>ALTER TABLE OO_EXECUTION_STATES_2 MODIFY PAYLOAD MEDIUMBLOB NOT NULL;</sql>
+        <sql>ALTER TABLE OO_EXECUTION_STATES MODIFY PAYLOAD MEDIUMBLOB NOT NULL;</sql>
     </changeSet>
 
     <changeSet id="create OO_EXECUTION_QUEUES" author="engine">

--- a/engine/node/score-node-impl/src/main/java/io/cloudslang/engine/node/services/WorkerNodeServiceImpl.java
+++ b/engine/node/score-node-impl/src/main/java/io/cloudslang/engine/node/services/WorkerNodeServiceImpl.java
@@ -12,10 +12,10 @@ package io.cloudslang.engine.node.services;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import io.cloudslang.score.api.nodes.WorkerStatus;
 import io.cloudslang.engine.node.entities.WorkerNode;
 import io.cloudslang.engine.node.repositories.WorkerNodeRepository;
 import io.cloudslang.engine.versioning.services.VersionService;
+import io.cloudslang.score.api.nodes.WorkerStatus;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Propagation;
@@ -23,9 +23,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author
@@ -260,7 +261,12 @@ public class WorkerNodeServiceImpl implements WorkerNodeService {
 	@Transactional
 	public void updateWorkerGroups(String uuid, String... groupNames) {
 		WorkerNode worker = readByUUID(uuid);
-		List<String> groups = groupNames != null ? Arrays.asList(groupNames) : Collections.<String> emptyList();
+
+		Set<String> groupSet = groupNames != null ? new HashSet<>(Arrays.asList(groupNames)) : new HashSet<String>();
+		List<String> groups = new ArrayList<>();
+		groupSet.remove(null);
+		groups.addAll(groupSet);
+
 		worker.setGroups(groups);
 	}
 
@@ -281,10 +287,18 @@ public class WorkerNodeServiceImpl implements WorkerNodeService {
 	@Override
 	@Transactional
 	public void addGroupToWorker(String workerUuid, String group) {
+
+		if (group == null) {
+			return;
+		}
+
 		WorkerNode worker = readByUUID(workerUuid);
-		List<String> groups = new ArrayList<>(worker.getGroups());
-		groups.add(group);
-		worker.setGroups(groups);
+
+		if (!worker.getGroups().contains(group)) {
+			List<String> groups = new ArrayList<>(worker.getGroups());
+			groups.add(group);
+			worker.setGroups(groups);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
fixes #75
score.changes.xml : removed alter table OO_EXECUTION_STATES_{1,2} since they don't not exist anymore and cause failure on mysql and liquibase.

WorkerNodeServiceImpl: modif the 2 methods of adding a worker to a group so that it removes duplicates, and to not allow null group.

The test was changed to create the database structure with liquibase, not hibernate auto DDL, and a new test method was added to test that a worker can't be added in the same group twice.