### PR TITLE
Correct the typos in the WorkerMonitorInfoEnum

### DIFF
--- a/worker/worker-manager/score-worker-manager-api/src/main/java/io/cloudslang/worker/management/services/WorkerMonitorInfoEnum.java
+++ b/worker/worker-manager/score-worker-manager-api/src/main/java/io/cloudslang/worker/management/services/WorkerMonitorInfoEnum.java
@@ -11,7 +11,7 @@
 package io.cloudslang.worker.management.services;
 
 public enum WorkerMonitorInfoEnum {
-    WROKER_ID,
+    WORKER_ID,
     MONITOR_START_TIME,
     MONITOR_END_TIME,
 
@@ -19,12 +19,12 @@ public enum WorkerMonitorInfoEnum {
     INBUFFER_SIZE_AVERAGE,
 
     OUTBUFFER_CAPACITY,
-    OUTBUDDER_SIZE_AVERAGE,
+    OUTBUFFER_SIZE_AVERAGE,
 
     RUNNING_TASKS_AVERAGE,
     EXECUTION_THREADS_AMOUNT,
 
-    FREE_MOMORY,
-    MAX_MOMORY,
+    FREE_MEMORY,
+    MAX_MEMORY,
     TOTAL_MEMORY
 }

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/monitor/ScheduledWorkerLoadMonitor.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/monitor/ScheduledWorkerLoadMonitor.java
@@ -47,7 +47,7 @@ public class ScheduledWorkerLoadMonitor implements ScheduledWorkerMonitor{
     @Override
     public synchronized void captureMonitorInfo(Map<WorkerMonitorInfoEnum, Serializable> monitorInfo) {
         monitorInfo.put(WorkerMonitorInfoEnum.INBUFFER_SIZE_AVERAGE, probeCount > 0 ? inBufferSize / probeCount : 0);
-        monitorInfo.put(WorkerMonitorInfoEnum.OUTBUDDER_SIZE_AVERAGE, probeCount > 0 ? outBufferSize / probeCount : 0);
+        monitorInfo.put(WorkerMonitorInfoEnum.OUTBUFFER_SIZE_AVERAGE, probeCount > 0 ? outBufferSize / probeCount : 0);
         monitorInfo.put(WorkerMonitorInfoEnum.RUNNING_TASKS_AVERAGE, probeCount > 0 ? runningTasks / probeCount : 0);
         resetMonitor();
     }

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/monitor/WorkerMonitorsImpl.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/monitor/WorkerMonitorsImpl.java
@@ -48,10 +48,10 @@ public class WorkerMonitorsImpl implements WorkerMonitors {
 
             Runtime runtime = Runtime.getRuntime();
             monitorInfo.put(WorkerMonitorInfoEnum.TOTAL_MEMORY, runtime.totalMemory());
-            monitorInfo.put(WorkerMonitorInfoEnum.FREE_MOMORY, runtime.freeMemory());
-            monitorInfo.put(WorkerMonitorInfoEnum.MAX_MOMORY, runtime.maxMemory());
+            monitorInfo.put(WorkerMonitorInfoEnum.FREE_MEMORY, runtime.freeMemory());
+            monitorInfo.put(WorkerMonitorInfoEnum.MAX_MEMORY, runtime.maxMemory());
 
-            monitorInfo.put(WorkerMonitorInfoEnum.WROKER_ID, workerManager.getWorkerUuid());
+            monitorInfo.put(WorkerMonitorInfoEnum.WORKER_ID, workerManager.getWorkerUuid());
 
             monitorInfo.put(WorkerMonitorInfoEnum.EXECUTION_THREADS_AMOUNT, workerManager.getExecutionThreadsCount());
 

--- a/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/monitor/ScheduledWorkerLoadMonitorTest.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/monitor/ScheduledWorkerLoadMonitorTest.java
@@ -59,7 +59,7 @@ public class ScheduledWorkerLoadMonitorTest {
         monitor.captureMonitorInfo(monitorInfo);
 
         assertEquals(0, monitorInfo.get(WorkerMonitorInfoEnum.INBUFFER_SIZE_AVERAGE));
-        assertEquals(0, monitorInfo.get(WorkerMonitorInfoEnum.OUTBUDDER_SIZE_AVERAGE));
+        assertEquals(0, monitorInfo.get(WorkerMonitorInfoEnum.OUTBUFFER_SIZE_AVERAGE));
         assertEquals(0, monitorInfo.get(WorkerMonitorInfoEnum.RUNNING_TASKS_AVERAGE));
 
         monitor.executeScheduled();
@@ -67,14 +67,14 @@ public class ScheduledWorkerLoadMonitorTest {
         monitor.captureMonitorInfo(monitorInfo);
 
         assertEquals(10, monitorInfo.get(WorkerMonitorInfoEnum.INBUFFER_SIZE_AVERAGE));
-        assertEquals(2000, monitorInfo.get(WorkerMonitorInfoEnum.OUTBUDDER_SIZE_AVERAGE));
+        assertEquals(2000, monitorInfo.get(WorkerMonitorInfoEnum.OUTBUFFER_SIZE_AVERAGE));
         assertEquals(5, monitorInfo.get(WorkerMonitorInfoEnum.RUNNING_TASKS_AVERAGE));
 
         monitor.captureMonitorInfo(monitorInfo);
 
         //after capture should be reset
         assertEquals(0, monitorInfo.get(WorkerMonitorInfoEnum.INBUFFER_SIZE_AVERAGE));
-        assertEquals(0, monitorInfo.get(WorkerMonitorInfoEnum.OUTBUDDER_SIZE_AVERAGE));
+        assertEquals(0, monitorInfo.get(WorkerMonitorInfoEnum.OUTBUFFER_SIZE_AVERAGE));
         assertEquals(0, monitorInfo.get(WorkerMonitorInfoEnum.RUNNING_TASKS_AVERAGE));
 
         reset(workerManager, outboundBuffer);
@@ -96,7 +96,7 @@ public class ScheduledWorkerLoadMonitorTest {
         monitor.captureMonitorInfo(monitorInfo);
 
         assertEquals(15, monitorInfo.get(WorkerMonitorInfoEnum.INBUFFER_SIZE_AVERAGE));
-        assertEquals(2500, monitorInfo.get(WorkerMonitorInfoEnum.OUTBUDDER_SIZE_AVERAGE));
+        assertEquals(2500, monitorInfo.get(WorkerMonitorInfoEnum.OUTBUFFER_SIZE_AVERAGE));
         assertEquals(6, monitorInfo.get(WorkerMonitorInfoEnum.RUNNING_TASKS_AVERAGE));
     }
 

--- a/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/monitor/WorkerMonitorsImplTest.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/monitor/WorkerMonitorsImplTest.java
@@ -65,9 +65,9 @@ public class WorkerMonitorsImplTest {
 
         Map<WorkerMonitorInfoEnum, Serializable> monitorInfo = workerMonitors.getMonitorInfo();
         assertNotNull(monitorInfo.get(WorkerMonitorInfoEnum.TOTAL_MEMORY));
-        assertNotNull(monitorInfo.get(WorkerMonitorInfoEnum.FREE_MOMORY));
-        assertNotNull(monitorInfo.get(WorkerMonitorInfoEnum.MAX_MOMORY));
-        assertNotNull(monitorInfo.get(WorkerMonitorInfoEnum.WROKER_ID));
+        assertNotNull(monitorInfo.get(WorkerMonitorInfoEnum.FREE_MEMORY));
+        assertNotNull(monitorInfo.get(WorkerMonitorInfoEnum.MAX_MEMORY));
+        assertNotNull(monitorInfo.get(WorkerMonitorInfoEnum.WORKER_ID));
         assertNotNull(monitorInfo.get(WorkerMonitorInfoEnum.EXECUTION_THREADS_AMOUNT));
         assertEquals(5, monitorInfo.get(WorkerMonitorInfoEnum.EXECUTION_THREADS_AMOUNT));
         assertNotNull(monitorInfo.get(WorkerMonitorInfoEnum.OUTBUFFER_CAPACITY));


### PR DESCRIPTION
fixes #79 
This is a solution for the defect: WorkerExecutionMonitorServiceImpl messages contain several typos #79 