### PR TITLE
Added busyWorkersService that eliminates redundant DB requests from central

### DIFF
--- a/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/services/BusyWorkersService.java
+++ b/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/services/BusyWorkersService.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
+
+
+package io.cloudslang.engine.queue.services;
+
+public interface BusyWorkersService {
+    boolean isWorkerBusy(String workerId);
+    void findBusyWorkers();
+}

--- a/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepository.java
+++ b/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepository.java
@@ -46,4 +46,5 @@ public interface ExecutionQueueRepository {
     Set<Long> getFinishedExecStateIds();
 
 	List<ExecutionMessage> findByStatuses(int maxSize, ExecStatus... statuses);
+	List<String> getBusyWorkers(ExecStatus... statuses);
 }

--- a/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepositoryImpl.java
+++ b/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepositoryImpl.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 
 package io.cloudslang.engine.queue.repositories;
 
@@ -46,19 +46,19 @@ import java.util.Set;
 @SuppressWarnings("FieldCanBeLocal")
 public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 
-    private Logger logger = Logger.getLogger(getClass());
+	private Logger logger = Logger.getLogger(getClass());
 
-    final private String SELECT_FINISHED_STEPS_IDS =  " SELECT DISTINCT EXEC_STATE_ID FROM OO_EXECUTION_QUEUES " +
-                                                      " WHERE " +
-                                                      "        (STATUS = "+ExecStatus.TERMINATED.getNumber()+") OR " +
-                                                      "        (STATUS = "+ExecStatus.FAILED.getNumber()+") OR " +
-                                                      "        (STATUS = "+ExecStatus.FINISHED.getNumber()+") ";
+	final private String SELECT_FINISHED_STEPS_IDS =  " SELECT DISTINCT EXEC_STATE_ID FROM OO_EXECUTION_QUEUES " +
+			" WHERE " +
+			"        (STATUS = "+ExecStatus.TERMINATED.getNumber()+") OR " +
+			"        (STATUS = "+ExecStatus.FAILED.getNumber()+") OR " +
+			"        (STATUS = "+ExecStatus.FINISHED.getNumber()+") ";
 
 	final private String QUERY_DELETE_FINISHED_STEPS_FROM_QUEUES = "DELETE FROM OO_EXECUTION_QUEUES " +
 			" WHERE EXEC_STATE_ID in (:ids)";
 
-    final private String QUERY_DELETE_FINISHED_STEPS_FROM_STATES = "DELETE FROM OO_EXECUTION_STATES " +
-    			" WHERE ID in (:ids)";
+	final private String QUERY_DELETE_FINISHED_STEPS_FROM_STATES = "DELETE FROM OO_EXECUTION_STATES " +
+			" WHERE ID in (:ids)";
 
 	final private String QUERY_MESSAGES_WITHOUT_ACK_SQL =
 			"SELECT EXEC_STATE_ID,      " +
@@ -79,19 +79,19 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 					"      (q.MSG_VERSION < ?) ";
 
 
-    final private String QUERY_COUNT_MESSAGES_WITHOUT_ACK_FOR_WORKER_SQL =
-            "SELECT COUNT(*)  " +
-                        "  FROM  OO_EXECUTION_QUEUES  q  " +
-                        "  WHERE " +
-                        "      (q.ASSIGNED_WORKER  = ? ) AND " +
-                        "      (q.STATUS  = ? ) AND " +
-                        "     (NOT EXISTS (SELECT qq.MSG_SEQ_ID " +
-                        "                  FROM OO_EXECUTION_QUEUES qq " +
-                        "                  WHERE (qq.EXEC_STATE_ID = q.EXEC_STATE_ID) AND " +
-                        "                        qq.MSG_SEQ_ID > q.MSG_SEQ_ID " +
-                        "                 )" +
-                        "      ) AND " +
-                        "      (q.MSG_VERSION < ?)  ";
+	final private String QUERY_COUNT_MESSAGES_WITHOUT_ACK_FOR_WORKER_SQL =
+			"SELECT COUNT(*)  " +
+					"  FROM  OO_EXECUTION_QUEUES  q  " +
+					"  WHERE " +
+					"      (q.ASSIGNED_WORKER  = ? ) AND " +
+					"      (q.STATUS  = ? ) AND " +
+					"     (NOT EXISTS (SELECT qq.MSG_SEQ_ID " +
+					"                  FROM OO_EXECUTION_QUEUES qq " +
+					"                  WHERE (qq.EXEC_STATE_ID = q.EXEC_STATE_ID) AND " +
+					"                        qq.MSG_SEQ_ID > q.MSG_SEQ_ID " +
+					"                 )" +
+					"      ) AND " +
+					"      (q.MSG_VERSION < ?)  ";
 
 
 	final private String QUERY_WORKER_SQL =
@@ -114,24 +114,24 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 					"              WHERE (qq.EXEC_STATE_ID = q.EXEC_STATE_ID) AND qq.MSG_SEQ_ID > q.MSG_SEQ_ID)) " +
 					" ORDER BY q.CREATE_TIME  ";
 
-    final private String QUERY_WORKER_RECOVERY_SQL =
-            "SELECT         EXEC_STATE_ID,      " +
-                    "       ASSIGNED_WORKER,      " +
-                    "       EXEC_GROUP,       " +
-                    "       STATUS,       " +
-                    "       PAYLOAD,       " +
-                    "       MSG_SEQ_ID,      " +
-                    "       MSG_ID," +
-                    "       q.CREATE_TIME " +
-                    " FROM  OO_EXECUTION_QUEUES q,  " +
-                    "       OO_EXECUTION_STATES s1   " +
-                    " WHERE  " +
-                    "      (q.ASSIGNED_WORKER =  ?)  AND " +
-                    "      (q.STATUS IN (:status)) AND " +
-                    " q.EXEC_STATE_ID = s1.ID AND" +
-                    " (NOT EXISTS (SELECT qq.MSG_SEQ_ID " +
-                    "              FROM OO_EXECUTION_QUEUES qq " +
-                    "              WHERE (qq.EXEC_STATE_ID = q.EXEC_STATE_ID) AND qq.MSG_SEQ_ID > q.MSG_SEQ_ID)) ";
+	final private String QUERY_WORKER_RECOVERY_SQL =
+			"SELECT         EXEC_STATE_ID,      " +
+					"       ASSIGNED_WORKER,      " +
+					"       EXEC_GROUP,       " +
+					"       STATUS,       " +
+					"       PAYLOAD,       " +
+					"       MSG_SEQ_ID,      " +
+					"       MSG_ID," +
+					"       q.CREATE_TIME " +
+					" FROM  OO_EXECUTION_QUEUES q,  " +
+					"       OO_EXECUTION_STATES s1   " +
+					" WHERE  " +
+					"      (q.ASSIGNED_WORKER =  ?)  AND " +
+					"      (q.STATUS IN (:status)) AND " +
+					" q.EXEC_STATE_ID = s1.ID AND" +
+					" (NOT EXISTS (SELECT qq.MSG_SEQ_ID " +
+					"              FROM OO_EXECUTION_QUEUES qq " +
+					"              WHERE (qq.EXEC_STATE_ID = q.EXEC_STATE_ID) AND qq.MSG_SEQ_ID > q.MSG_SEQ_ID)) ";
 
 	final private String QUERY_MESSAGES_BY_STATUSES =
 			"SELECT EXEC_STATE_ID, " +
@@ -149,6 +149,16 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 					"         qq.EXEC_STATE_ID = q.EXEC_STATE_ID" +
 					"         AND qq.MSG_SEQ_ID > q.MSG_SEQ_ID" +
 					"  )";
+	final private String BUSY_WORKERS_SQL =
+			"SELECT ASSIGNED_WORKER      " +
+					" FROM  OO_EXECUTION_QUEUES q  " +
+					" WHERE  " +
+					"      (q.STATUS IN (:status)) AND " +
+					" (NOT EXISTS (SELECT qq.MSG_SEQ_ID " +
+					"              FROM OO_EXECUTION_QUEUES qq " +
+					"              WHERE (qq.EXEC_STATE_ID = q.EXEC_STATE_ID) AND qq.MSG_SEQ_ID > q.MSG_SEQ_ID)) " +
+					" GROUP BY ASSIGNED_WORKER";
+
 
 	final private String INSERT_EXEC_STATE = "INSERT INTO OO_EXECUTION_STATES  (ID, MSG_ID,  PAYLOAD, CREATE_TIME) VALUES (?, ?, ?, CURRENT_TIMESTAMP)";
 
@@ -157,16 +167,17 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 	private static final String QUERY_PAYLOAD_BY_EXECUTION_IDS = "SELECT ID, PAYLOAD FROM OO_EXECUTION_STATES WHERE ID IN (:IDS)";
 
 
-    //We use dedicated JDBCTemplates for each query since JDBCTemplate is state-full object and we have different settings for each query.
-    private JdbcTemplate insertExecutionJDBCTemplate;
-    private JdbcTemplate pollJDBCTemplate;
-    private JdbcTemplate pollForRecoveryJDBCTemplate;
-    private JdbcTemplate getFinishedExecStateIdsJDBCTemplate;
-    private JdbcTemplate deleteFinishedStepsJDBCTemplate;
-    private JdbcTemplate pollMessagesWithoutAckJDBCTemplate;
-    private JdbcTemplate countMessagesWithoutAckForWorkerJDBCTemplate;
-    private JdbcTemplate findPayloadByExecutionIdsJDBCTemplate;
-    private JdbcTemplate findByStatusesJDBCTemplate;
+	//We use dedicated JDBCTemplates for each query since JDBCTemplate is state-full object and we have different settings for each query.
+	private JdbcTemplate insertExecutionJDBCTemplate;
+	private JdbcTemplate pollJDBCTemplate;
+	private JdbcTemplate pollForRecoveryJDBCTemplate;
+	private JdbcTemplate getFinishedExecStateIdsJDBCTemplate;
+	private JdbcTemplate deleteFinishedStepsJDBCTemplate;
+	private JdbcTemplate pollMessagesWithoutAckJDBCTemplate;
+	private JdbcTemplate countMessagesWithoutAckForWorkerJDBCTemplate;
+	private JdbcTemplate findPayloadByExecutionIdsJDBCTemplate;
+	private JdbcTemplate findByStatusesJDBCTemplate;
+	private JdbcTemplate getBusyWorkersTemplate;
 
 
 	@Autowired
@@ -177,17 +188,18 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 
 	@PostConstruct
 	public void init() {
-        //We use dedicated JDBCTemplates for each query since JDBCTemplate is state-full object and we have different settings for each query.
-        this.insertExecutionJDBCTemplate = new JdbcTemplate(dataSource);
-        this.pollJDBCTemplate = new JdbcTemplate(dataSource);
-        this.pollForRecoveryJDBCTemplate = new JdbcTemplate(dataSource);
-        this.getFinishedExecStateIdsJDBCTemplate = new JdbcTemplate(dataSource);
-        this.deleteFinishedStepsJDBCTemplate = new JdbcTemplate(dataSource);
-        this.pollMessagesWithoutAckJDBCTemplate = new JdbcTemplate(dataSource);
-        this.countMessagesWithoutAckForWorkerJDBCTemplate = new JdbcTemplate(dataSource);
-        this.findPayloadByExecutionIdsJDBCTemplate = new JdbcTemplate(dataSource);
-        this.findByStatusesJDBCTemplate = new JdbcTemplate(dataSource);
-    }
+		//We use dedicated JDBCTemplates for each query since JDBCTemplate is state-full object and we have different settings for each query.
+		this.insertExecutionJDBCTemplate = new JdbcTemplate(dataSource);
+		this.pollJDBCTemplate = new JdbcTemplate(dataSource);
+		this.pollForRecoveryJDBCTemplate = new JdbcTemplate(dataSource);
+		this.getFinishedExecStateIdsJDBCTemplate = new JdbcTemplate(dataSource);
+		this.deleteFinishedStepsJDBCTemplate = new JdbcTemplate(dataSource);
+		this.pollMessagesWithoutAckJDBCTemplate = new JdbcTemplate(dataSource);
+		this.countMessagesWithoutAckForWorkerJDBCTemplate = new JdbcTemplate(dataSource);
+		this.findPayloadByExecutionIdsJDBCTemplate = new JdbcTemplate(dataSource);
+		this.findByStatusesJDBCTemplate = new JdbcTemplate(dataSource);
+		this.getBusyWorkersTemplate = new JdbcTemplate(dataSource);
+	}
 
 	@Override
 	public long generateExecStateId() {
@@ -197,7 +209,7 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 	@Override
 	public void insertExecutionStates(final List<ExecutionMessage> stateMessages) {
 		String insertExecStateSQL = INSERT_EXEC_STATE;
-        insertExecutionJDBCTemplate.batchUpdate(insertExecStateSQL, new BatchPreparedStatementSetter() {
+		insertExecutionJDBCTemplate.batchUpdate(insertExecStateSQL, new BatchPreparedStatementSetter() {
 
 			@Override
 			public void setValues(PreparedStatement ps, int i) throws SQLException {
@@ -221,7 +233,7 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 		String insertQueueSQL = INSERT_QUEUE;
 
 		long t = System.currentTimeMillis();
-        insertExecutionJDBCTemplate.batchUpdate(insertQueueSQL, new BatchPreparedStatementSetter() {
+		insertExecutionJDBCTemplate.batchUpdate(insertQueueSQL, new BatchPreparedStatementSetter() {
 			@Override
 			public void setValues(PreparedStatement ps, int i) throws SQLException {
 				ExecutionMessage msg = messages.get(i);
@@ -247,34 +259,34 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 	@Override
 	public List<ExecutionMessage> pollRecovery(String workerId, int maxSize, ExecStatus... statuses) {
 
-        pollForRecoveryJDBCTemplate.setMaxRows(maxSize);
-        pollForRecoveryJDBCTemplate.setFetchSize(maxSize);
+		pollForRecoveryJDBCTemplate.setMaxRows(maxSize);
+		pollForRecoveryJDBCTemplate.setFetchSize(maxSize);
 
-        // prepare the sql statement
-        String sqlStatPrvTable = QUERY_WORKER_RECOVERY_SQL
-                .replaceAll(":status", StringUtils.repeat("?", ",", statuses.length));
+		// prepare the sql statement
+		String sqlStatPrvTable = QUERY_WORKER_RECOVERY_SQL
+				.replaceAll(":status", StringUtils.repeat("?", ",", statuses.length));
 
-        // prepare the argument
-        java.lang.Object[] values;
-        values = new Object[statuses.length + 1];
-        values[0] = workerId;
-        int i = 1;
+		// prepare the argument
+		java.lang.Object[] values;
+		values = new Object[statuses.length + 1];
+		values[0] = workerId;
+		int i = 1;
 
-        for (ExecStatus status : statuses) {
-            values[i++] = status.getNumber();
-        }
+		for (ExecStatus status : statuses) {
+			values[i++] = status.getNumber();
+		}
 
-        return doSelectWithTemplate(pollForRecoveryJDBCTemplate, sqlStatPrvTable, new ExecutionMessageRowMapper(), values);
+		return doSelectWithTemplate(pollForRecoveryJDBCTemplate, sqlStatPrvTable, new ExecutionMessageRowMapper(), values);
 	}
 
 
 	@Override
 	public List<ExecutionMessage> poll(String workerId, int maxSize, ExecStatus... statuses) {
 
-        pollJDBCTemplate.setMaxRows(maxSize);
-        pollJDBCTemplate.setFetchSize(maxSize);
+		pollJDBCTemplate.setMaxRows(maxSize);
+		pollJDBCTemplate.setFetchSize(maxSize);
 
-        // prepare the sql statement
+		// prepare the sql statement
 		String sqlStat = QUERY_WORKER_SQL
 				.replaceAll(":status", StringUtils.repeat("?", ",", statuses.length));
 
@@ -299,29 +311,29 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 		// Access STATES first and then QUEUES - same order as ExecutionQueueService#enqueue (prevents deadlocks on MSSQL)
 		String query = QUERY_DELETE_FINISHED_STEPS_FROM_STATES.replaceAll(":ids", StringUtils.repeat("?", ",", ids.size()));
 
-        Object[] args = ids.toArray(new Object[ids.size()]);
-        logSQL(query,args);
+		Object[] args = ids.toArray(new Object[ids.size()]);
+		logSQL(query,args);
 
-        int deletedRows = deleteFinishedStepsJDBCTemplate.update(query, args); //MUST NOT set here maxRows!!!! It must delete all without limit!!!
+		int deletedRows = deleteFinishedStepsJDBCTemplate.update(query, args); //MUST NOT set here maxRows!!!! It must delete all without limit!!!
 
-        if(logger.isDebugEnabled()){
-            logger.debug("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_STATES table.");
-        }
+		if(logger.isDebugEnabled()){
+			logger.debug("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_STATES table.");
+		}
 
-        query = QUERY_DELETE_FINISHED_STEPS_FROM_QUEUES.replaceAll(":ids", StringUtils.repeat("?", ",", ids.size()));
-        logSQL(query,args);
+		query = QUERY_DELETE_FINISHED_STEPS_FROM_QUEUES.replaceAll(":ids", StringUtils.repeat("?", ",", ids.size()));
+		logSQL(query,args);
 
-        deletedRows = deleteFinishedStepsJDBCTemplate.update(query, args); //MUST NOT set here maxRows!!!! It must delete all without limit!!!
+		deletedRows = deleteFinishedStepsJDBCTemplate.update(query, args); //MUST NOT set here maxRows!!!! It must delete all without limit!!!
 
-        if(logger.isDebugEnabled()){
-            logger.debug("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_QUEUES table.");
-        }
-    }
+		if(logger.isDebugEnabled()){
+			logger.debug("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_QUEUES table.");
+		}
+	}
 
-    @Override
-    public Set<Long> getFinishedExecStateIds() {
-        getFinishedExecStateIdsJDBCTemplate.setMaxRows(1000000);
-        getFinishedExecStateIdsJDBCTemplate.setFetchSize(1000000);
+	@Override
+	public Set<Long> getFinishedExecStateIds() {
+		getFinishedExecStateIdsJDBCTemplate.setMaxRows(1000000);
+		getFinishedExecStateIdsJDBCTemplate.setFetchSize(1000000);
 
 		List<Long> result = doSelectWithTemplate(getFinishedExecStateIdsJDBCTemplate, SELECT_FINISHED_STEPS_IDS, new SingleColumnRowMapper<>(Long.class));
 
@@ -333,8 +345,8 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 
 		String sqlStat = QUERY_MESSAGES_WITHOUT_ACK_SQL;
 
-        pollMessagesWithoutAckJDBCTemplate.setMaxRows(maxSize);
-        pollMessagesWithoutAckJDBCTemplate.setFetchSize(maxSize);
+		pollMessagesWithoutAckJDBCTemplate.setMaxRows(maxSize);
+		pollMessagesWithoutAckJDBCTemplate.setFetchSize(maxSize);
 
 		Object[] values = {
 				ExecStatus.SENT.getNumber(),
@@ -347,10 +359,10 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 
 		if (result.size() > 0) {
 			logger.warn("Pool " + result.size() + " messages without ack, version = " + minVersionAllowed);
-            if(logger.isDebugEnabled()){
-                for (ExecutionMessage msg : result) {
-                    logger.debug("Recovery msg [" + msg.getExecStateId() + "," + msg.getStatus() + "," + msg.getCreateDate() + "]");
-			}}
+			if(logger.isDebugEnabled()){
+				for (ExecutionMessage msg : result) {
+					logger.debug("Recovery msg [" + msg.getExecStateId() + "," + msg.getStatus() + "," + msg.getCreateDate() + "]");
+				}}
 		}
 		if (logger.isTraceEnabled())
 			logger.trace("Query [" + sqlStat + "] took " + (System.currentTimeMillis() - time) + " ms");
@@ -361,36 +373,36 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 		return result;
 	}
 
-    public Integer countMessagesWithoutAckForWorker(int maxSize, long minVersionAllowed, String workerUuid) {
-        countMessagesWithoutAckForWorkerJDBCTemplate.setMaxRows(maxSize);
-        countMessagesWithoutAckForWorkerJDBCTemplate.setFetchSize(maxSize);
+	public Integer countMessagesWithoutAckForWorker(int maxSize, long minVersionAllowed, String workerUuid) {
+		countMessagesWithoutAckForWorkerJDBCTemplate.setMaxRows(maxSize);
+		countMessagesWithoutAckForWorkerJDBCTemplate.setFetchSize(maxSize);
 
-        Object[] values = {
-                workerUuid,
-                ExecStatus.SENT.getNumber(),
-                minVersionAllowed,
+		Object[] values = {
+				workerUuid,
+				ExecStatus.SENT.getNumber(),
+				minVersionAllowed,
 
-        };
+		};
 
-        long time = System.currentTimeMillis();
-        Integer result = countMessagesWithoutAckForWorkerJDBCTemplate.queryForObject(QUERY_COUNT_MESSAGES_WITHOUT_ACK_FOR_WORKER_SQL, values,Integer.class);
+		long time = System.currentTimeMillis();
+		Integer result = countMessagesWithoutAckForWorkerJDBCTemplate.queryForObject(QUERY_COUNT_MESSAGES_WITHOUT_ACK_FOR_WORKER_SQL, values,Integer.class);
 
-        if (logger.isTraceEnabled())
-            logger.trace("Query [" + QUERY_COUNT_MESSAGES_WITHOUT_ACK_FOR_WORKER_SQL + "] took " + (System.currentTimeMillis() - time) + " ms");
+		if (logger.isTraceEnabled())
+			logger.trace("Query [" + QUERY_COUNT_MESSAGES_WITHOUT_ACK_FOR_WORKER_SQL + "] took " + (System.currentTimeMillis() - time) + " ms");
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Got msg without ack :" + result + ",for version:" + minVersionAllowed + ",for worker:" + workerUuid);
-        }
-        return result;
-    }
+		if (logger.isDebugEnabled()) {
+			logger.debug("Got msg without ack :" + result + ",for version:" + minVersionAllowed + ",for worker:" + workerUuid);
+		}
+		return result;
+	}
 
 	@Override
 	public Map<Long, Payload> findPayloadByExecutionIds(Long... ids) {
-        String qMarks = StringUtils.repeat("?", ",", ids.length);
-        String sqlStat = QUERY_PAYLOAD_BY_EXECUTION_IDS.replace(":IDS", qMarks);
+		String qMarks = StringUtils.repeat("?", ",", ids.length);
+		String sqlStat = QUERY_PAYLOAD_BY_EXECUTION_IDS.replace(":IDS", qMarks);
 
 		final Map<Long, Payload> result = new HashMap<>();
-        findPayloadByExecutionIdsJDBCTemplate.query(sqlStat, ids, new RowCallbackHandler() {
+		findPayloadByExecutionIdsJDBCTemplate.query(sqlStat, ids, new RowCallbackHandler() {
 			@Override
 			public void processRow(ResultSet resultSet) throws SQLException {
 				result.put(
@@ -405,8 +417,8 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 
 	@Override
 	public List<ExecutionMessage> findByStatuses(int maxSize, ExecStatus... statuses) {
-        findByStatusesJDBCTemplate.setMaxRows(maxSize);
-        findByStatusesJDBCTemplate.setFetchSize(maxSize);
+		findByStatusesJDBCTemplate.setMaxRows(maxSize);
+		findByStatusesJDBCTemplate.setFetchSize(maxSize);
 
 		// prepare the sql statement
 		String sqlStat = QUERY_MESSAGES_BY_STATUSES
@@ -425,6 +437,30 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 			throw ex;
 		}
 	}
+
+	@Override
+	public List<String> getBusyWorkers(ExecStatus... statuses) {
+		//todo Change to stream when score is upgraded to java 8
+		// prepare the sql statement
+		String sqlStat = BUSY_WORKERS_SQL
+				.replaceAll(":status", StringUtils.repeat("?", ",", statuses.length));
+		// prepare the argument
+		Object[] values = new Object[statuses.length];
+		int i=0;
+		for (ExecStatus status : statuses) {
+			values[i] = status.getNumber();
+		}
+		return doSelectWithTemplate(getBusyWorkersTemplate, sqlStat, new BusyWorkerRowMapper(), values);
+	}
+
+	private class BusyWorkerRowMapper implements RowMapper<String> {
+		@Override
+		public String mapRow(ResultSet rs, int rowNum) throws SQLException {
+			return rs.getString("ASSIGNED_WORKER");
+		}
+	}
+
+
 
 	private class ExecutionMessageRowMapper implements RowMapper<ExecutionMessage> {
 		@Override
@@ -455,7 +491,7 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 	}
 
 	private <T> List<T> doSelectWithTemplate(JdbcTemplate jdbcTemplate, String sql, RowMapper<T> rowMapper, Object... params) {
-        logSQL(sql,params);
+		logSQL(sql,params);
 		try {
 			long t = System.currentTimeMillis();
 			List<T> result = jdbcTemplate.query(sql, params, rowMapper);
@@ -468,10 +504,10 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 		}
 	}
 
-    private void logSQL(String query, Object... params) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Execute SQL: " + query);
-            if (params != null && params.length > 1) logger.debug("Parameters : " + Arrays.toString(params));
-        }
-    }
+	private void logSQL(String query, Object... params) {
+		if (logger.isDebugEnabled()) {
+			logger.debug("Execute SQL: " + query);
+			if (params != null && params.length > 1) logger.debug("Parameters : " + Arrays.toString(params));
+		}
+	}
 }

--- a/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/services/BusyWorkersServiceImpl.java
+++ b/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/services/BusyWorkersServiceImpl.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
+
+package io.cloudslang.engine.queue.services;
+import io.cloudslang.engine.queue.entities.ExecStatus;
+import io.cloudslang.engine.queue.repositories.ExecutionQueueRepository;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BusyWorkersServiceImpl implements BusyWorkersService{
+
+    private final Logger logger = Logger.getLogger(BusyWorkersServiceImpl.class);
+    private List<String> busyWorkers = new ArrayList<>();
+
+    @Autowired
+    private ExecutionQueueRepository executionQueueRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isWorkerBusy(String workerId) {
+        return busyWorkers.contains(workerId);
+    }
+    @Override
+    @Transactional(readOnly = true)
+    public void findBusyWorkers() {
+        long startTime = 0;
+        if (logger.isDebugEnabled()) {
+            startTime = System.currentTimeMillis();
+            logger.debug("Querying for busy workers...");
+        }
+        busyWorkers = executionQueueRepository.getBusyWorkers(ExecStatus.ASSIGNED);
+
+        if (logger.isDebugEnabled()) {
+            long endTime = System.currentTimeMillis();
+            logger.debug("Queried for busy workers, the following workers are busy: " + this.busyWorkers + ". Query took: " + (endTime - startTime) + " ms to complete");
+        }
+    }
+
+}

--- a/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/services/ExecutionQueueServiceImpl.java
+++ b/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/services/ExecutionQueueServiceImpl.java
@@ -43,6 +43,9 @@ final public class ExecutionQueueServiceImpl implements ExecutionQueueService {
 	@Autowired
 	private ExecutionAssignerService executionAssignerService;
 
+	@Autowired
+	private BusyWorkersService busyWorkersService;
+
 	@Autowired(required = false)
 	private List<QueueListener> listeners = Collections.emptyList();
 
@@ -136,7 +139,10 @@ final public class ExecutionQueueServiceImpl implements ExecutionQueueService {
 	@Override
 	@Transactional(readOnly = true)
 	public List<ExecutionMessage> poll(String workerId, int maxSize, ExecStatus... statuses) {
-		List<ExecutionMessage> result = executionQueueRepository.poll(workerId, maxSize, statuses);
+		List<ExecutionMessage> result = new ArrayList<>();
+		//check if the worker has work before actually polling for work
+		if(busyWorkersService.isWorkerBusy(workerId))
+		result = executionQueueRepository.poll(workerId, maxSize, statuses);
 
 		for (QueueListener listener : listeners) {
 			listener.onPoll(result, result.size());

--- a/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepositoryTest.java
+++ b/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepositoryTest.java
@@ -215,6 +215,20 @@ public class ExecutionQueueRepositoryTest {
         Assert.assertFalse(result.isEmpty());
     }
 
+    @Test
+    public void testGetBusyWorkersBusyWorker(){
+        List<ExecutionMessage> msg = new ArrayList<>();
+        ExecutionMessage execMsg = generateMessage("group1","msg1", 1);
+        execMsg.setWorkerId("worker1");
+        execMsg.setStatus(ExecStatus.IN_PROGRESS);
+        execMsg.incMsgSeqId();
+        msg.add(execMsg);
+        executionQueueRepository.insertExecutionStates(msg);
+        executionQueueRepository.insertExecutionQueue(msg,1L);
+        List<String> busyWorkers = executionQueueRepository.getBusyWorkers(ExecStatus.ASSIGNED);
+        Assert.assertNotNull(busyWorkers);
+    }
+
     private ExecutionMessage generateMessage(String groupName,String msgId, int msg_seq_id) {
         byte[] payloadData;
         payloadData = "This is just a test".getBytes();

--- a/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/services/BusyWorkersServiceTest.java
+++ b/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/services/BusyWorkersServiceTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
+
+
+package io.cloudslang.engine.queue.services;
+
+import io.cloudslang.engine.queue.entities.ExecStatus;
+import io.cloudslang.engine.queue.repositories.ExecutionQueueRepository;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+
+@ContextConfiguration
+public class BusyWorkersServiceTest {
+
+
+
+    @Autowired
+    private BusyWorkersService busyWorkersService;
+
+    @Autowired
+    private ExecutionQueueRepository executionQueueRepository;
+
+    @Before
+    public void setUp()
+    {
+        MockitoAnnotations.initMocks(this);
+        reset(executionQueueRepository);
+    }
+
+    @Test
+    public void testIdleWorker(){
+        List<String> busyWorkers = new ArrayList<>();
+        when(executionQueueRepository.getBusyWorkers(ExecStatus.ASSIGNED)).thenReturn(busyWorkers);
+        Assert.assertFalse(busyWorkersService.isWorkerBusy("worker1"));
+    }
+
+    @Test
+    public void testBusyWorker(){
+        List<String> busyWorkers = new ArrayList<>();
+        busyWorkers.add("worker1");
+        when(executionQueueRepository.getBusyWorkers(ExecStatus.ASSIGNED)).thenReturn(busyWorkers);
+        busyWorkersService.findBusyWorkers();
+        Assert.assertTrue(busyWorkersService.isWorkerBusy("worker1"));
+    }
+
+
+    @Configuration
+    static class EmptyConfig {
+        @Bean
+        public BusyWorkersService busyWorkersService(){
+            return new BusyWorkersServiceImpl();
+        }
+
+        @Bean
+        public ExecutionQueueRepository executionQueueRepository(){
+            return mock(ExecutionQueueRepository.class);
+        }
+    }
+}

--- a/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/services/ExecutionQueueServiceTest.java
+++ b/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/services/ExecutionQueueServiceTest.java
@@ -65,6 +65,9 @@ public class ExecutionQueueServiceTest {
 	public WorkerNodeService workerNodeService;
 
 	@Autowired
+	private BusyWorkersService busyWorkersService;
+
+	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
 	@Autowired
@@ -190,7 +193,8 @@ public class ExecutionQueueServiceTest {
 		groupWorkerMap.put("group1", "worker1");
 		groupWorkerMap.put("group1", "worker2");
 		when(workerNodeService.readGroupWorkersMapActiveAndRunningAndVersion("")).thenReturn(groupWorkerMap);
-
+		when(busyWorkersService.isWorkerBusy("worker1")).thenReturn(true);
+		when(busyWorkersService.isWorkerBusy("worker1")).thenReturn(true);
 		List<ExecutionMessage> msgInQueue = executionQueueService.pollMessagesWithoutAck(100, 0);
 		Assert.assertEquals(0, msgInQueue.size());
 
@@ -312,6 +316,11 @@ public class ExecutionQueueServiceTest {
 		@Bean
 		public WorkerNodeService workerNodeService() {
 			return mock(WorkerNodeService.class);
+		}
+
+		@Bean
+		public BusyWorkersService busyWorkersService() {
+			return mock(BusyWorkersService.class);
 		}
 
 		@Bean

--- a/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/services/QueueDispatcherServiceTest.java
+++ b/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/services/QueueDispatcherServiceTest.java
@@ -41,6 +41,8 @@ public class QueueDispatcherServiceTest {
     @Mock
     private ExecutionQueueService executionQueueService;
 
+    @Mock
+    private BusyWorkersService busyWorkersService;
 
     @InjectMocks
     private QueueDispatcherService queueDispatcherService = new QueueDispatcherServiceImpl();
@@ -75,6 +77,7 @@ public class QueueDispatcherServiceTest {
     @Test
     public void testPoll() throws Exception {
         Date now = new Date();
+        when(busyWorkersService.isWorkerBusy("workerId")).thenReturn(true);
         queueDispatcherService.poll("workerId",5);
         verify(executionQueueService,times(1)).poll("workerId", 5, ExecStatus.ASSIGNED);
     }

--- a/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerServiceTest.java
+++ b/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerServiceTest.java
@@ -19,6 +19,7 @@ import io.cloudslang.engine.queue.entities.ExecutionMessageConverter;
 import io.cloudslang.engine.queue.entities.Payload;
 import io.cloudslang.engine.queue.repositories.ExecutionQueueRepository;
 import io.cloudslang.engine.queue.repositories.ExecutionQueueRepositoryImpl;
+import io.cloudslang.engine.queue.services.BusyWorkersService;
 import io.cloudslang.engine.queue.services.ExecutionQueueService;
 import io.cloudslang.engine.queue.services.ExecutionQueueServiceImpl;
 import io.cloudslang.engine.queue.services.assigner.ExecutionAssignerService;
@@ -66,6 +67,9 @@ public class QueueCleanerServiceTest {
 	public QueueCleanerService queueCleanerService;
 
 	@Autowired
+	private BusyWorkersService busyWorkersService;
+
+	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
 
@@ -83,7 +87,7 @@ public class QueueCleanerServiceTest {
 
 		ExecutionMessage message25 = generateMessage(2, "group1", "2", ExecStatus.IN_PROGRESS, 1);
 		ExecutionMessage message26 = generateMessage(2, "group1", "2", ExecStatus.FINISHED, 2);
-
+		when(busyWorkersService.isWorkerBusy("myWorker")).thenReturn(true);
 		msgs.clear();
 		msgs.add(message15);
 		executionQueueService.enqueue(msgs);
@@ -182,6 +186,11 @@ public class QueueCleanerServiceTest {
 		@Bean
 		WorkerNodeService workerNodeService() {
 			return mock(WorkerNodeService.class);
+		}
+
+		@Bean
+		public BusyWorkersService busyWorkersService() {
+			return mock(BusyWorkersService.class);
 		}
 
 		@Bean

--- a/package/score-all/src/main/java/io/cloudslang/schema/EngineBeanDefinitionParser.java
+++ b/package/score-all/src/main/java/io/cloudslang/schema/EngineBeanDefinitionParser.java
@@ -15,11 +15,7 @@ import io.cloudslang.engine.node.services.WorkerNodeServiceImpl;
 import io.cloudslang.engine.node.services.WorkersMBean;
 import io.cloudslang.engine.queue.entities.ExecutionMessageConverter;
 import io.cloudslang.engine.queue.repositories.ExecutionQueueRepositoryImpl;
-import io.cloudslang.engine.queue.services.ExecutionQueueServiceImpl;
-import io.cloudslang.engine.queue.services.QueueDispatcherServiceImpl;
-import io.cloudslang.engine.queue.services.QueueListenerImpl;
-import io.cloudslang.engine.queue.services.QueueStateIdGeneratorServiceImpl;
-import io.cloudslang.engine.queue.services.ScoreEventFactoryImpl;
+import io.cloudslang.engine.queue.services.*;
 import io.cloudslang.engine.queue.services.assigner.ExecutionAssignerServiceImpl;
 import io.cloudslang.engine.queue.services.cleaner.QueueCleanerServiceImpl;
 import io.cloudslang.engine.queue.services.recovery.ExecutionRecoveryServiceImpl;
@@ -107,6 +103,7 @@ public class EngineBeanDefinitionParser extends AbstractBeanDefinitionParser {
         put(WorkerDbSupportServiceImpl.class, null);
         put(ScoreDeprecatedImpl.class, null);
         put(ScoreEngineJobsImpl.class,"scoreEngineJobs");
+		put(BusyWorkersServiceImpl.class,"busyWorkersService");
 	}};
 
 	@Override

--- a/package/score-all/src/main/resources/META-INF/spring/score/context/scoreEngineSchedulerContext.xml
+++ b/package/score-all/src/main/resources/META-INF/spring/score/context/scoreEngineSchedulerContext.xml
@@ -9,5 +9,6 @@
         <task:scheduled ref="scoreEngineJobs" method="cleanQueueJob" fixed-delay="60000" initial-delay="120000" />
         <task:scheduled ref="scoreEngineJobs" method="recoveryVersionJob" fixed-delay="30000" initial-delay="6000" />
         <task:scheduled ref="scoreEngineJobs" method="executionRecoveryJob" fixed-delay="120000" initial-delay="120000" />
+        <task:scheduled ref="busyWorkersService" method="findBusyWorkers" fixed-delay="200" initial-delay="200" />
     </task:scheduled-tasks>
 </beans>

--- a/score-tests/src/test/java/io/cloudslang/schema/EngineTest.java
+++ b/score-tests/src/test/java/io/cloudslang/schema/EngineTest.java
@@ -70,7 +70,7 @@ public class EngineTest {
     private QueueDispatcherService dispatcherService;
 
     @Test
-    public void baseEngineTest() {
+    public void baseEngineTest() throws InterruptedException {
         // register worker
         workerNodeService.create("uuid", "password", "host", "dir");
         workerNodeService.activate("uuid");
@@ -79,7 +79,7 @@ public class EngineTest {
         ExecutionPlan executionPlan = createExecutionPlan();
         TriggeringProperties triggeringProperties = TriggeringProperties.create(executionPlan);
         score.trigger(triggeringProperties);
-
+        Thread.sleep(300);
         List<ExecutionMessage> messages = dispatcherService.poll("uuid", 10);
 
         assertThat(messages).hasSize(1);


### PR DESCRIPTION
Added busyWorkersService that eliminates redundant DB requests from central
when  workers that do not have work poll the central for work

Signed-off by: Doron Sekler doron.sekler@hpe.com