### PR TITLE
Increased java version to 1.8 and removed `maven-compiler-plugin` plu…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
         <spring.version>4.3.10.RELEASE</spring.version>
         <hibernate.version>5.0.12.Final</hibernate.version>
         <querydsl.version>3.6.9</querydsl.version>
@@ -451,15 +454,6 @@
                 </plugin>
 
                 <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.0</version>
-                    <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
-                    </configuration>
-                </plugin>
-
-                <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>2.14</version>
                     <executions>
@@ -509,9 +503,6 @@
                                     <requireMavenVersion>
                                         <version>3.0.4</version>
                                     </requireMavenVersion>
-                                    <requireJavaVersion>
-                                        <version>1.7</version>
-                                    </requireJavaVersion>
                                 </rules>
                             </configuration>
                         </execution>
@@ -557,14 +548,6 @@
       <plugins>
           <plugin>
               <artifactId>maven-enforcer-plugin</artifactId>
-          </plugin>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                  <source>1.7</source>
-                  <target>1.7</target>
-              </configuration>
           </plugin>
       </plugins>
     </build>


### PR DESCRIPTION
Increased java version to 1.8 and removed `maven-compiler-plugin` plugin in favor of <maven.compiler.*> properties

Signed-off-by: Victor Ursan <victor.ursan@hpe.com>