### PR TITLE
Revert hibernate upgrade to 5.0.12.Final

### DIFF
--- a/engine/data/score-data-api/src/main/java/io/cloudslang/engine/data/SimpleHiloIdentifierGenerator.java
+++ b/engine/data/score-data-api/src/main/java/io/cloudslang/engine/data/SimpleHiloIdentifierGenerator.java
@@ -18,7 +18,7 @@ package io.cloudslang.engine.data;
 
 import org.apache.log4j.Logger;
 import org.hibernate.HibernateException;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.id.IdentifierGenerator;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.SingleConnectionDataSource;
@@ -77,7 +77,7 @@ public class SimpleHiloIdentifierGenerator implements IdentifierGenerator, Ident
     }
 
     @Override
-    public Serializable generate(SharedSessionContractImplementor session, Object object)
+    public Serializable generate(SessionImplementor session, Object object)
             throws HibernateException {
         lock.lock();
         try {

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <mysql.connector.version>5.1.35</mysql.connector.version>
         <postgres.driver.version>9.1-901.jdbc4</postgres.driver.version>
         <spring.version>4.3.17.RELEASE</spring.version>
-        <hibernate.version>5.2.15.Final</hibernate.version>
+        <hibernate.version>5.0.12.Final</hibernate.version>
         <querydsl.version>4.2.1</querydsl.version>
         <!--Project properties-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Revert hibernate upgrade to 5.0.12.Final due to order_inserts=true and order_update=true impacting some unit tests after hibernate upgrade