### PR TITLE
Activate/deactivate new timeout mechanism

### DIFF
--- a/worker/worker-execution/score-worker-execution-impl/src/main/java/io/cloudslang/worker/execution/model/SandboxExecutionRunnable.java
+++ b/worker/worker-execution/score-worker-execution-impl/src/main/java/io/cloudslang/worker/execution/model/SandboxExecutionRunnable.java
@@ -50,4 +50,11 @@ public class SandboxExecutionRunnable<T> implements Runnable {
 
         bundle.set(new ImmutablePair<>(processingResult, processingException));
     }
+
+    public void afterExecute() {
+        final Pair<T, RuntimeException> localBundle = bundle.get();
+        if (localBundle.getRight() != null) {
+            throw localBundle.getRight();
+        }
+    }
 }

--- a/worker/worker-execution/score-worker-execution-impl/src/main/java/io/cloudslang/worker/execution/services/ExecutionServiceImpl.java
+++ b/worker/worker-execution/score-worker-execution-impl/src/main/java/io/cloudslang/worker/execution/services/ExecutionServiceImpl.java
@@ -61,6 +61,8 @@ import static java.lang.Boolean.getBoolean;
 import static java.lang.Integer.getInteger;
 import static java.lang.Long.getLong;
 import static java.lang.String.valueOf;
+import static java.lang.Thread.currentThread;
+import static org.apache.commons.lang.StringUtils.endsWith;
 
 
 public final class ExecutionServiceImpl implements ExecutionService {
@@ -416,7 +418,7 @@ public final class ExecutionServiceImpl implements ExecutionService {
                     long now = System.currentTimeMillis();
                     Callable<Object> operationCallable = () -> reflectionAdapter.executeControlAction(action, stepData);
                     SandboxExecutionRunnable<Object> sandboxExecutionRunnable =
-                            new SandboxExecutionRunnable<>(Thread.currentThread().getContextClassLoader(), operationCallable);
+                            new SandboxExecutionRunnable<>(currentThread().getContextClassLoader(), operationCallable);
                     Thread operationExecutionThread = new Thread(sandboxExecutionRunnable);
 
                     long dynamicTimeout = getDynamicTimeout(startTime, timeoutMins, now);
@@ -462,7 +464,7 @@ public final class ExecutionServiceImpl implements ExecutionService {
 
     private boolean isContentOperationStep(ControlActionMetadata action) {
         return (action != null) && StringUtils.equals(action.getMethodName(), EXECUTE_CONTENT_ACTION) &&
-                StringUtils.endsWith(action.getClassName(), EXECUTE_CONTENT_ACTION_CLASSNAME);
+                endsWith(action.getClassName(), EXECUTE_CONTENT_ACTION_CLASSNAME);
     }
 
     private long getDynamicTimeout(long startTime, int timeoutMins, long now) {

--- a/worker/worker-execution/score-worker-execution-impl/src/test/java/io/cloudslang/worker/execution/services/ExecutionServiceTest.java
+++ b/worker/worker-execution/score-worker-execution-impl/src/test/java/io/cloudslang/worker/execution/services/ExecutionServiceTest.java
@@ -58,6 +58,7 @@ import static io.cloudslang.score.facade.execution.PauseReason.SEQUENTIAL_EXECUT
 import static java.lang.Boolean.TRUE;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -317,6 +318,7 @@ public class ExecutionServiceTest {
         timeoutExecutionService.executeStep(exe, executionStep);
 
         assertEquals(0, exe.getPosition().longValue()); //position is still 0
+        assertFalse(exe.getSystemContext().hasStepErrorKey()); //there is error in context
     }
 
     @Test

--- a/worker/worker-execution/score-worker-execution-impl/src/test/java/io/cloudslang/worker/execution/services/ExecutionServiceTest.java
+++ b/worker/worker-execution/score-worker-execution-impl/src/test/java/io/cloudslang/worker/execution/services/ExecutionServiceTest.java
@@ -282,32 +282,28 @@ public class ExecutionServiceTest {
 	public void executeStepTest() throws InterruptedException {
 		//Test no exception is thrown - all is caught inside
 		ExecutionStep executionStep = new ExecutionStep(EXECUTION_STEP_1_ID);
-		executionStep.setActionData(new HashMap<String, Serializable>());
+		Map<String, Serializable> actionData = new HashMap<>();
+		actionData.put("actionType", "content");
+		executionStep.setActionData(actionData);
+		executionStep.setAction(RUNTIME_EXCEPTION_METADATA);
 
 		Execution exe = new Execution(0L, 0L, new HashMap<String, String>());
 
-        HashMap<String, Serializable> actionData = new HashMap<>();
-        actionData.put("actionType", "content");
-        executionStep.setActionData(actionData);
-        executionStep.setAction(RUNTIME_EXCEPTION_METADATA);
-        executionStep.setActionData(new HashMap<String, Serializable>());
-
 		executionService.executeStep(exe, executionStep);
 
-		assertEquals(0, exe.getPosition().longValue()); //position is still 0
+		assertEquals(0, exe.getPosition().longValue()); // position is still 0
 		assertTrue(exe.getSystemContext().hasStepErrorKey()); //there is error in context
 	}
 
     @Test
     public void executeStepTestWithEnabledTimeoutGoesWellWithoutExceptionOrTimeout() throws InterruptedException {
-        //Test no exception is thrown - all is caught inside
+        // Test no exception is thrown - all is caught inside
         ExecutionStep executionStep = new ExecutionStep(EXECUTION_STEP_1_ID);
 
-        HashMap<String, Serializable> actionData = new HashMap<>();
+        Map<String, Serializable> actionData = new HashMap<>();
         actionData.put("actionType", "content");
         executionStep.setActionData(actionData);
         executionStep.setAction(CONTENT_EXEC_CONTROL_ACTION_METADATA);
-        executionStep.setActionData(new HashMap<String, Serializable>());
 
         when(reflectionAdapter.executeControlAction(eq(CONTENT_EXEC_CONTROL_ACTION_METADATA), any(Map.class))).thenReturn(null);
 
@@ -317,8 +313,8 @@ public class ExecutionServiceTest {
 
         timeoutExecutionService.executeStep(exe, executionStep);
 
-        assertEquals(0, exe.getPosition().longValue()); //position is still 0
-        assertFalse(exe.getSystemContext().hasStepErrorKey()); //there is error in context
+        assertEquals(0, exe.getPosition().longValue()); // position is still 0
+        assertFalse(exe.getSystemContext().hasStepErrorKey());
     }
 
     @Test
@@ -326,11 +322,10 @@ public class ExecutionServiceTest {
         //Test no exception is thrown - all is caught inside
         ExecutionStep executionStep = new ExecutionStep(EXECUTION_STEP_1_ID);
 
-        HashMap<String, Serializable> actionData = new HashMap<>();
+        Map<String, Serializable> actionData = new HashMap<>();
         actionData.put("actionType", "content");
         executionStep.setActionData(actionData);
         executionStep.setAction(CONTENT_EXEC_CONTROL_ACTION_METADATA);
-        executionStep.setActionData(new HashMap<String, Serializable>());
 
         Execution exe = new Execution(0L, 0L, new HashMap<String, String>());
         exe.getSystemContext().put("SC_TIMEOUT_START_TIME", System.currentTimeMillis());


### PR DESCRIPTION
Provide a way to activate deactivate the new timeout mechanism, by using `enable.new.timeout=true|false` system property. When the system property is not specified. it will default to `false`.
Fix case when execution on delegating thread did not propagate exception back to original executor thread.


