### PR TITLE
Flows were stuck in running for RPA Activities

### DIFF
--- a/worker/worker-execution/score-worker-execution-api/src/main/java/io/cloudslang/worker/execution/services/ExecutionService.java
+++ b/worker/worker-execution/score-worker-execution-api/src/main/java/io/cloudslang/worker/execution/services/ExecutionService.java
@@ -39,6 +39,13 @@ public interface ExecutionService {
      */
 	Execution execute(Execution execution) throws InterruptedException;
 
+    /**
+     * This method MUST be used ONLY for pausing sequential executions.
+     * @param execution the {@link io.cloudslang.score.facade.entities.Execution} to pause
+     * @throws InterruptedException
+     */
+	void pauseSequentialExecution(Execution execution) throws InterruptedException;
+
     void postExecutionWork(Execution execution) throws InterruptedException;
 
     /**

--- a/worker/worker-execution/score-worker-execution-api/src/main/java/io/cloudslang/worker/execution/services/ExecutionService.java
+++ b/worker/worker-execution/score-worker-execution-api/src/main/java/io/cloudslang/worker/execution/services/ExecutionService.java
@@ -37,7 +37,7 @@ public interface ExecutionService {
      * @return the {@link io.cloudslang.score.facade.entities.Execution} after executing
      * @throws InterruptedException
      */
-	Execution execute(Execution execution) throws InterruptedException;
+    Execution execute(Execution execution) throws InterruptedException;
 
     /**
      * This method MUST be used ONLY for pausing sequential executions.

--- a/worker/worker-execution/score-worker-execution-api/src/main/java/io/cloudslang/worker/execution/services/ExecutionService.java
+++ b/worker/worker-execution/score-worker-execution-api/src/main/java/io/cloudslang/worker/execution/services/ExecutionService.java
@@ -44,7 +44,7 @@ public interface ExecutionService {
      * @param execution the {@link io.cloudslang.score.facade.entities.Execution} to pause
      * @throws InterruptedException
      */
-	void pauseSequentialExecution(Execution execution) throws InterruptedException;
+    void pauseSequentialExecution(Execution execution) throws InterruptedException;
 
     void postExecutionWork(Execution execution) throws InterruptedException;
 

--- a/worker/worker-execution/score-worker-execution-api/src/main/java/io/cloudslang/worker/execution/services/ExternalExecutionService.java
+++ b/worker/worker-execution/score-worker-execution-api/src/main/java/io/cloudslang/worker/execution/services/ExternalExecutionService.java
@@ -18,6 +18,7 @@ package io.cloudslang.worker.execution.services;
 import io.cloudslang.score.facade.entities.Execution;
 
 public interface ExternalExecutionService {
+    void pauseExternalExecution(Execution execution) throws InterruptedException;
 
     void resumeExternalExecution(Execution execution) throws InterruptedException;
 

--- a/worker/worker-execution/score-worker-execution-impl/src/main/java/io/cloudslang/worker/execution/services/ExecutionServiceImpl.java
+++ b/worker/worker-execution/score-worker-execution-impl/src/main/java/io/cloudslang/worker/execution/services/ExecutionServiceImpl.java
@@ -146,7 +146,7 @@ public final class ExecutionServiceImpl implements ExecutionService {
             }
             if ((!execution.getSystemContext().hasStepErrorKey()) && currStep.getActionData().get(ACTION_TYPE) != null &&
                     currStep.getActionData().get(ACTION_TYPE).toString().equalsIgnoreCase(SEQUENTIAL)) {
-                pauseFlow(execution, robotAvailabilityService.isRobotAvailable("Default") ? PENDING_ROBOT : NO_ROBOTS_IN_GROUP);
+                // Stop the execution here, the rest of the steps are done by the Sequential Message Handler
                 return null;
             }
             // Run the navigation
@@ -171,6 +171,13 @@ public final class ExecutionServiceImpl implements ExecutionService {
             execution.setPosition(null); // this ends the flow!!!
             return execution;
         }
+    }
+
+    @Override
+    public void pauseSequentialExecution(Execution execution) throws InterruptedException {
+        final PauseReason pauseReason =
+                robotAvailabilityService.isRobotAvailable("Default") ? PENDING_ROBOT : NO_ROBOTS_IN_GROUP;
+        pauseFlow(execution, pauseReason);
     }
 
     @Override

--- a/worker/worker-execution/score-worker-execution-impl/src/main/java/io/cloudslang/worker/execution/services/ExternalExecutionServiceImpl.java
+++ b/worker/worker-execution/score-worker-execution-impl/src/main/java/io/cloudslang/worker/execution/services/ExternalExecutionServiceImpl.java
@@ -34,6 +34,11 @@ public final class ExternalExecutionServiceImpl implements ExternalExecutionServ
     private ExecutionService executionService;
 
     @Override
+    public void pauseExternalExecution(Execution execution) throws InterruptedException {
+        executionService.pauseSequentialExecution(execution);
+    }
+
+    @Override
     public void resumeExternalExecution(Execution execution) {
         pauseService.resumeExecution(execution.getExecutionId(),
                 execution.getSystemContext().getBranchId(), new HashMap<>());

--- a/worker/worker-execution/score-worker-execution-impl/src/test/java/io/cloudslang/worker/execution/services/ExecutionServiceTest.java
+++ b/worker/worker-execution/score-worker-execution-impl/src/test/java/io/cloudslang/worker/execution/services/ExecutionServiceTest.java
@@ -213,8 +213,6 @@ public class ExecutionServiceTest {
 
 		//running execution plan id has not changed as result of not navigating
 		assertEquals(RUNNING_EXE_PLAN_ID, execution.getRunningExecutionPlanId());
-		Mockito.verify(pauseResumeService, VerificationModeFactory.times(1)).pauseExecution(any(Long.class), any(String.class), eq(NO_ROBOTS_IN_GROUP));
-		Mockito.verify(pauseResumeService, VerificationModeFactory.times(1)).writeExecutionObject(any(Long.class), any(String.class), eq(execution));
 		Mockito.verifyNoMoreInteractions(pauseResumeService);
 	}
 


### PR DESCRIPTION
Flows were stuck in running for RPA Activities if on production environments (Faster environments).

This was happening due to the order of execution steps. First the message/execution was produced on queue, and then it was paused.
This triggered a race condition in which if there was some sort of check on the execution between putting the message on the queue and pausing the execution, a null pointer was thrown.
What was done: reverted the order (pause -> execute), removed the set pause status from other places, changed how the doAction method works in Cloudslang such that the runEnvironment is fully populated before pausing (and persisting) the execution.
Also fixed another defect that made the Multi Instance with one lane having RPA activities fail because the branchId was mistakenly removed from the RpaExecutionMessage

Signed-off-by: platon <platonicaaa@hotmail.com>