### PR TITLE
Prevent polling when worker is not active

### DIFF
--- a/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/entities/WorkerKeepAliveInfo.java
+++ b/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/entities/WorkerKeepAliveInfo.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.engine.node.entities;
+
+
+import java.io.Serializable;
+
+public class WorkerKeepAliveInfo implements Serializable {
+
+    private static final long serialVersionUID = -7807186903493660070L;
+
+    private final String workerRecoveryVersion;
+    private final boolean active;
+
+    public WorkerKeepAliveInfo(String workerRecoveryVersion, boolean active) {
+        this.workerRecoveryVersion = workerRecoveryVersion;
+        this.active = active;
+    }
+
+    public String getWorkerRecoveryVersion() {
+        return workerRecoveryVersion;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+}

--- a/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/services/WorkerNodeService.java
+++ b/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/services/WorkerNodeService.java
@@ -17,6 +17,7 @@
 package io.cloudslang.engine.node.services;
 
 import com.google.common.collect.Multimap;
+import io.cloudslang.engine.node.entities.WorkerKeepAliveInfo;
 import io.cloudslang.engine.node.entities.WorkerNode;
 import io.cloudslang.score.api.nodes.WorkerStatus;
 
@@ -35,9 +36,17 @@ public interface WorkerNodeService {
     /**
      * Update the Worker Node entity with the current ack version for the keep alive mechanism
      * @param uuid worker's unique identifier
+     * Maintained for backward compatibility only
      * @return the worker's recovery version (WRV)
      */
 	String keepAlive(String uuid);
+
+    /**
+     * Update the Worker Node entity with the current ack version for the keep alive mechanism
+     * @param uuid worker's unique identifier
+     * @return the WorkerKeepAliveInfo that contains the worker's recovery version (WRV) and the enable state
+     */
+    WorkerKeepAliveInfo newKeepAlive(String uuid);
 
     /**
      * Create a new worker

--- a/engine/node/score-node-impl/src/main/java/io/cloudslang/engine/node/services/WorkerNodeServiceImpl.java
+++ b/engine/node/score-node-impl/src/main/java/io/cloudslang/engine/node/services/WorkerNodeServiceImpl.java
@@ -80,8 +80,9 @@ public class WorkerNodeServiceImpl implements WorkerNodeService {
         if (!worker.getStatus().equals(WorkerStatus.IN_RECOVERY)) {
             worker.setStatus(WorkerStatus.RUNNING);
         }
-        logger.debug("Got keepAlive for Worker with uuid=" + uuid + " and update its ackVersion to " + version);
-        return new WorkerKeepAliveInfo(worker.getWorkerRecoveryVersion(), worker.isActive());
+        boolean active = worker.isActive();
+        logger.debug("Got keepAlive for Worker with uuid=" + uuid + " and update its ackVersion to " + version + " isActive" + active);
+        return new WorkerKeepAliveInfo(worker.getWorkerRecoveryVersion(), active);
     }
 
     @Override

--- a/package/score-worker/src/main/java/io/cloudslang/schema/WorkerBeanDefinitionParser.java
+++ b/package/score-worker/src/main/java/io/cloudslang/schema/WorkerBeanDefinitionParser.java
@@ -28,6 +28,7 @@ import io.cloudslang.worker.management.WorkerConfigurationServiceImpl;
 import io.cloudslang.worker.management.WorkerRegistration;
 import io.cloudslang.worker.management.monitor.ScheduledWorkerLoadMonitor;
 import io.cloudslang.worker.management.monitor.WorkerMonitorsImpl;
+import io.cloudslang.worker.management.monitor.WorkerStateUpdateServiceImpl;
 import io.cloudslang.worker.management.services.InBuffer;
 import io.cloudslang.worker.management.services.OutboundBufferImpl;
 import io.cloudslang.worker.management.services.RetryTemplate;
@@ -66,6 +67,7 @@ public class WorkerBeanDefinitionParser extends AbstractBeanDefinitionParser {
 		put(ExecutionServiceImpl.class, "agent");
 		put(InBuffer.class, null);
 		put(WorkerConfigurationUtils.class, null);
+		put(WorkerStateUpdateServiceImpl.class, null);
 		put(OutboundBufferImpl.class, "outBuffer");
 		put(RetryTemplate.class, null);
 		put(SimpleExecutionRunnableFactory.class, null);

--- a/worker/worker-manager/score-worker-manager-api/src/main/java/io/cloudslang/worker/management/monitor/WorkerStateUpdateService.java
+++ b/worker/worker-manager/score-worker-manager-api/src/main/java/io/cloudslang/worker/management/monitor/WorkerStateUpdateService.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.worker.management.monitor;
+
+
+public interface WorkerStateUpdateService {
+    boolean isWorkerEnabled();
+    void setEnableState(boolean newState);
+}

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/monitor/WorkerStateUpdateServiceImpl.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/monitor/WorkerStateUpdateServiceImpl.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.worker.management.monitor;
+
+
+public class WorkerStateUpdateServiceImpl implements WorkerStateUpdateService {
+
+    private boolean active;
+
+    @Override
+    public synchronized boolean isWorkerEnabled() {
+        return active;
+    }
+
+    @Override
+    public synchronized void setEnableState(boolean newState) {
+         active = newState;
+    }
+
+}

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/InBuffer.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/InBuffer.java
@@ -21,6 +21,7 @@ import io.cloudslang.engine.queue.entities.ExecutionMessage;
 import io.cloudslang.engine.queue.entities.Payload;
 import io.cloudslang.engine.queue.services.QueueDispatcherService;
 import io.cloudslang.worker.management.ExecutionsActivityListener;
+import io.cloudslang.worker.management.monitor.WorkerStateUpdateService;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,6 +86,9 @@ public class InBuffer implements WorkerRecoveryListener, ApplicationListener, Ru
     @Autowired
     private WorkerConfigurationUtils workerConfigurationUtils;
 
+    @Autowired
+    private WorkerStateUpdateService workerStateUpdateService;
+
     private Thread fillBufferThread = new Thread(this);
     private boolean inShutdown;
     private boolean endOfInit = false;
@@ -143,6 +147,11 @@ public class InBuffer implements WorkerRecoveryListener, ApplicationListener, Ru
                     // We need to check if the current thread was interrupted while waiting for the lock (InBufferThread) and RESET its interrupted flag!
                     if (Thread.interrupted()) {
                         logger.info("Thread was interrupted while waiting on the lock in fillBufferPeriodically()");
+                        continue;
+                    }
+
+                    if (!workerStateUpdateService.isWorkerEnabled()) {
+                        logger.debug("Worker is disabled, skipping polling.");
                         continue;
                     }
 

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/InBuffer.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/InBuffer.java
@@ -100,7 +100,7 @@ public class InBuffer implements WorkerRecoveryListener, ApplicationListener, Ru
     private double workerFreeMemoryRatio;
 
     @PostConstruct
-    private void init() {
+    void init() {
         capacity = getInteger("worker.inbuffer.capacity", capacity);
         coolDownPollingMillis = getInteger("worker.inbuffer.coolDownPollingMillis", coolDownPollingMillis);
         logger.info("InBuffer capacity is set to :" + capacity

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/WorkerManager.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/WorkerManager.java
@@ -16,9 +16,11 @@
 
 package io.cloudslang.worker.management.services;
 
+import io.cloudslang.engine.node.entities.WorkerKeepAliveInfo;
 import io.cloudslang.engine.node.services.WorkerNodeService;
 import io.cloudslang.orchestrator.services.EngineVersionService;
 import io.cloudslang.worker.management.WorkerConfigurationService;
+import io.cloudslang.worker.management.monitor.WorkerStateUpdateService;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -96,6 +98,9 @@ public class WorkerManager implements ApplicationListener, EndExecutionCallback,
     @Autowired
     @Qualifier("inBufferCapacity")
     private Integer capacity;
+
+    @Autowired
+    private WorkerStateUpdateService workerStateUpdateService;
 
     private int keepAliveFailCount = 0;
 
@@ -188,7 +193,9 @@ public class WorkerManager implements ApplicationListener, EndExecutionCallback,
         if (!recoveryManager.isInRecovery()) {
             if (endOfInit) {
                 try {
-                    String newWrv = workerNodeService.keepAlive(workerUuid);
+                    WorkerKeepAliveInfo workerKeepAliveInfo = workerNodeService.newKeepAlive(workerUuid);
+                    String newWrv = workerKeepAliveInfo.getWorkerRecoveryVersion();
+                    workerStateUpdateService.setEnableState(workerKeepAliveInfo.isActive());
                     String currentWrv = recoveryManager.getWRV();
                     //do not update it!!! if it is different than we have - restart worker (clean state)
                     if (!currentWrv.equals(newWrv)) {

--- a/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/monitor/ScheduledWorkerLoadMonitorTest.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/monitor/ScheduledWorkerLoadMonitorTest.java
@@ -189,5 +189,11 @@ public class ScheduledWorkerLoadMonitorTest {
                     .getBlockingQueue(anyInt(), anyInt());
             return workerConfigurationUtils;
         }
+
+        @Bean
+        public WorkerStateUpdateService workerStateUpdateService() {
+            return mock(WorkerStateUpdateService.class);
+        }
+
     }
 }

--- a/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/monitor/WorkerMonitorsImplTest.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/monitor/WorkerMonitorsImplTest.java
@@ -243,6 +243,11 @@ public class WorkerMonitorsImplTest {
         }
 
         @Bean
+        public WorkerStateUpdateService workerStateUpdateService() {
+            return mock(WorkerStateUpdateService.class);
+        }
+
+        @Bean
         public ExecutionQueueService executionQueueService() {
             return mock(ExecutionQueueService.class);
         }

--- a/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/services/InBufferTest.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/services/InBufferTest.java
@@ -46,15 +46,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- * User: wahnonm Date: 15/08/13 Time: 11:32
- */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
 public class InBufferTest {
 
     @InjectMocks
-    @Spy
     private InBuffer inBuffer;
 
     @Mock
@@ -84,11 +78,6 @@ public class InBufferTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-    }
-
-    @Configuration
-    static class EmptyConfig {
-
     }
 
     @Test
@@ -137,7 +126,7 @@ public class InBufferTest {
             Thread thread = new Thread(inBuffer);
             thread.start();
 
-            // Wait 2 seconds
+            // Wait 1 second
             Thread.sleep(1000);
 
             // stop InBuffer operation
@@ -176,7 +165,7 @@ public class InBufferTest {
             Thread thread = new Thread(inBuffer);
             thread.start();
 
-            // Wait 2 seconds
+            // Wait 1 second
             Thread.sleep(1000);
 
             // stop InBuffer operation

--- a/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/services/InBufferTest.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/services/InBufferTest.java
@@ -17,31 +17,45 @@
 package io.cloudslang.worker.management.services;
 
 import io.cloudslang.engine.queue.services.QueueDispatcherService;
+import io.cloudslang.worker.management.monitor.WorkerStateUpdateService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static org.mockito.Mockito.*;
+import java.util.Collections;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 /**
-* User: wahnonm
-* Date: 15/08/13
-* Time: 11:32
-*/
+ * User: wahnonm Date: 15/08/13 Time: 11:32
+ */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 public class InBufferTest {
 
     @InjectMocks
-    private InBuffer inBuffer = new InBuffer();
+    @Spy
+    private InBuffer inBuffer;
 
     @Mock
     private QueueDispatcherService queueDispatcher;
@@ -61,13 +75,21 @@ public class InBufferTest {
     @Mock
     private SynchronizationManager synchronizationManager;
 
+    @Mock
+    private WorkerStateUpdateService workerStateUpdateService;
+
+    @Mock
+    private WorkerConfigurationUtils workerConfigurationUtils;
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
     }
 
     @Configuration
-    static class EmptyConfig {}
+    static class EmptyConfig {
+
+    }
 
     @Test
     public void testRunAfterCtxClosedEvent() throws Exception {
@@ -79,19 +101,101 @@ public class InBufferTest {
 
     @Test(timeout = 5000)
     public void testRunBeforeCtxClosedEvent() throws Exception {
-        ContextRefreshedEvent refreshEvent =  mock(ContextRefreshedEvent.class);
+        ContextRefreshedEvent refreshEvent = mock(ContextRefreshedEvent.class);
         inBuffer.onApplicationEvent(refreshEvent);
 
         ContextClosedEvent event = mock(ContextClosedEvent.class);
         when(workerManager.isUp()).thenReturn(true);
+        doReturn(true).when(workerStateUpdateService).isWorkerEnabled();
         Thread thread = new Thread(inBuffer);
         thread.start();
 
-        verify(workerManager,timeout(1000).atLeastOnce()).getInBufferSize();
+        verify(workerManager, timeout(1000).atLeastOnce()).getInBufferSize();
 
         inBuffer.onApplicationEvent(event);
-        while(thread.isAlive()){
-	        Thread.sleep(100L);
+        while (thread.isAlive()) {
+            Thread.sleep(100L);
         }
     }
+
+    @Test(timeout = 5000)
+    public void testPollingBehaviourOnWorkerEnabled() throws Exception {
+        System.setProperty("worker.inbuffer.capacity", "20");
+
+        try {
+            doReturn(true).when(workerManager).isUp();
+            doReturn(true).when(workerStateUpdateService).isWorkerEnabled();
+            doReturn(1).when(workerManager).getInBufferSize();
+
+            doNothing().when(synchronizationManager).finishGetMessages();
+            doNothing().when(synchronizationManager).startGetMessages();
+            doReturn(false).when(workerConfigurationUtils).isNewInbuffer();
+            doReturn(0.1).when(workerConfigurationUtils).getWorkerMemoryRatio();
+            doReturn(Collections.emptyList()).when(queueDispatcher).poll(anyString(), anyInt());
+
+            inBuffer.init();
+            Thread thread = new Thread(inBuffer);
+            thread.start();
+
+            // Wait 2 seconds
+            Thread.sleep(1000);
+
+            // stop InBuffer operation
+            new Thread(() -> {
+                ContextClosedEvent contextClosedEvent = mock(ContextClosedEvent.class);
+                inBuffer.onApplicationEvent(contextClosedEvent);
+            }).start();
+
+            // Wait for inbuffer to die
+            while (thread.isAlive()) {
+                Thread.sleep(50L);
+            }
+            verify(queueDispatcher, atLeastOnce()).poll(eq(null), eq(19));
+            verify(synchronizationManager, atLeastOnce()).finishGetMessages();
+        } finally {
+            System.clearProperty("worker.inbuffer.capacity");
+        }
+    }
+
+    @Test(timeout = 5000)
+    public void testPollingBehaviourOnWorkerDisabled() throws Exception {
+        System.setProperty("worker.inbuffer.capacity", "20");
+        try {
+
+            doReturn(true).when(workerManager).isUp();
+            doReturn(false).when(workerStateUpdateService).isWorkerEnabled();
+            doReturn(1).when(workerManager).getInBufferSize();
+
+            doNothing().when(synchronizationManager).finishGetMessages();
+            doNothing().when(synchronizationManager).startGetMessages();
+            doReturn(false).when(workerConfigurationUtils).isNewInbuffer();
+            doReturn(0.1).when(workerConfigurationUtils).getWorkerMemoryRatio();
+            doReturn(Collections.emptyList()).when(queueDispatcher).poll(anyString(), anyInt());
+
+            inBuffer.init();
+            Thread thread = new Thread(inBuffer);
+            thread.start();
+
+            // Wait 2 seconds
+            Thread.sleep(1000);
+
+            // stop InBuffer operation
+            new Thread(() -> {
+                ContextClosedEvent contextClosedEvent = mock(ContextClosedEvent.class);
+                inBuffer.onApplicationEvent(contextClosedEvent);
+            }).start();
+
+            // Wait for inbuffer to die
+            while (thread.isAlive()) {
+                Thread.sleep(50L);
+            }
+            verify(queueDispatcher, never()).poll(anyString(), anyInt());
+            verify(synchronizationManager, atLeastOnce()).finishGetMessages();
+        } finally {
+            System.clearProperty("worker.inbuffer.capacity");
+        }
+
+    }
+
+
 }

--- a/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/services/WorkerManagerTest.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/services/WorkerManagerTest.java
@@ -19,6 +19,7 @@ package io.cloudslang.worker.management.services;
 import io.cloudslang.engine.node.services.WorkerNodeService;
 import io.cloudslang.orchestrator.services.EngineVersionService;
 import io.cloudslang.worker.management.WorkerConfigurationService;
+import io.cloudslang.worker.management.monitor.WorkerStateUpdateService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -243,6 +244,11 @@ public class WorkerManagerTest {
 			WorkerConfigurationUtils workerConfigurationUtils = mock(WorkerConfigurationUtils.class);
 			doReturn(mock(LinkedBlockingQueue.class)).when(workerConfigurationUtils).getBlockingQueue(anyInt(), anyInt());
 			return workerConfigurationUtils;
+		}
+
+		@Bean
+		WorkerStateUpdateService workerStateUpdateService() {
+			return mock(WorkerStateUpdateService.class);
 		}
 
 		@Bean


### PR DESCRIPTION
When worker is not enabled, it will not perform polling for messages.

Signed-off-by: Lucian Musca lucian-cristian.musca@microfocus.com
