### PR TITLE
Limit concurrent python executions (+eval)

### DIFF
--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonExecutionEngineConfiguration.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonExecutionEngineConfiguration.java
@@ -25,6 +25,8 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import java.util.concurrent.Semaphore;
+
 /**
  * Created by Genadi Rabinovich, genadi@hpe.com on 05/05/2016.
  */
@@ -39,7 +41,8 @@ public class PythonExecutionEngineConfiguration {
 
     @Bean(name = "externalPythonRuntimeService")
     public PythonRuntimeService externalPythonRuntimeService() {
-        return new ExternalPythonRuntimeServiceImpl();
+        Integer pythonProcessPermits = Integer.getInteger("python.concurrent.execution.permits", 30);
+        return new ExternalPythonRuntimeServiceImpl(new Semaphore(pythonProcessPermits));
     }
 
     @Bean(name = "jythonExecutionEngine")

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonRuntimeServiceImpl.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonRuntimeServiceImpl.java
@@ -18,23 +18,76 @@ package io.cloudslang.runtime.impl.python.external;
 import io.cloudslang.runtime.api.python.PythonEvaluationResult;
 import io.cloudslang.runtime.api.python.PythonExecutionResult;
 import io.cloudslang.runtime.api.python.PythonRuntimeService;
+import org.apache.log4j.Logger;
 
 import javax.annotation.Resource;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 public class ExternalPythonRuntimeServiceImpl implements PythonRuntimeService {
+    private static final Logger logger = Logger.getLogger(ExternalPythonRuntimeServiceImpl.class);
+
+    private final Semaphore executionControlSemaphore;
+
+    public ExternalPythonRuntimeServiceImpl(Semaphore executionControlSemaphore) {
+        this.executionControlSemaphore = executionControlSemaphore;
+    }
+
     @Resource(name = "externalPythonExecutionEngine")
     private ExternalPythonExecutionNotCachedEngine externalPythonExecutionNotCachedEngine;
 
     @Override
     public PythonExecutionResult exec(Set<String> dependencies, String script, Map<String, Serializable> vars) {
-        return externalPythonExecutionNotCachedEngine.exec(dependencies, script, vars);
+        try {
+            if (executionControlSemaphore.tryAcquire(1L, TimeUnit.SECONDS)) {
+                try {
+                    return externalPythonExecutionNotCachedEngine.exec(dependencies, script, vars);
+                } finally {
+                    executionControlSemaphore.release();
+                }
+            } else {
+                logger.warn("Maximum number of python processes has been reached. Waiting for a python process to finish. " +
+                        "You can configure the number of concurrent python executions by setting " +
+                        "'python.concurrent.execution.permits' system property.");
+                executionControlSemaphore.acquire();
+                try {
+                    logger.info("Acquired a permit for a new python process. Continuing with execution...");
+                    return externalPythonExecutionNotCachedEngine.exec(dependencies, script, vars);
+                } finally {
+                    executionControlSemaphore.release();
+                }
+            }
+        } catch (InterruptedException ie) {
+            throw new ExternalPythonScriptException("Execution was interrupted while waiting for a python permit.");
+        }
     }
 
     @Override
     public PythonEvaluationResult eval(String prepareEnvironmentScript, String script, Map<String, Serializable> vars) {
-        return externalPythonExecutionNotCachedEngine.eval(prepareEnvironmentScript, script, vars);
+        try {
+            if (executionControlSemaphore.tryAcquire(1L, TimeUnit.SECONDS)) {
+                try {
+                    return externalPythonExecutionNotCachedEngine.eval(prepareEnvironmentScript, script, vars);
+                } finally {
+                    executionControlSemaphore.release();
+                }
+            } else {
+                logger.warn("Maximum number of python processes has been reached. Waiting for a python process to finish. " +
+                        "You can configure the number of concurrent python executions by setting " +
+                        "'python.concurrent.execution.permits' system property.");
+                executionControlSemaphore.acquire();
+                try {
+                    logger.info("Acquired a permit for a new python process. Continuing with execution...");
+                    return externalPythonExecutionNotCachedEngine.eval(prepareEnvironmentScript, script, vars);
+                } finally {
+                    executionControlSemaphore.release();
+                }
+            }
+        } catch (InterruptedException ie) {
+            throw new ExternalPythonScriptException("Execution was interrupted while waiting for a python permit.");
+        }
     }
 }

--- a/runtime-management/runtime-management-impl/src/test/java/io/cloudslang/runtime/impl/python/PythonExecutorTest.java
+++ b/runtime-management/runtime-management-impl/src/test/java/io/cloudslang/runtime/impl/python/PythonExecutorTest.java
@@ -50,6 +50,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -330,7 +331,7 @@ public class PythonExecutorTest {
 
         @Bean(name = "externalPythonRuntimeService")
         public PythonRuntimeService externalPythonRuntimeService() {
-            return new ExternalPythonRuntimeServiceImpl();
+            return new ExternalPythonRuntimeServiceImpl(new Semaphore(100));
         }
 
         @Bean(name = "jythonExecutionEngine")


### PR DESCRIPTION
Limit concurrent python executions (+eval)
Configurable using 'python.concurrent.execution.permits' system property

Signed-off-by: Tirla Florin-Alin <tirla@microfocus.com>