### PR TITLE
Outbuffer delay

### DIFF
--- a/package/score-worker/src/main/resources/META-INF/spring/score/context/scoreWorkerSchedulerContext.xml
+++ b/package/score-worker/src/main/resources/META-INF/spring/score/context/scoreWorkerSchedulerContext.xml
@@ -23,7 +23,7 @@
     -->
     <task:scheduler id="scoreOutboundBufferDrainer" pool-size="1" />
     <task:scheduled-tasks scheduler="scoreOutboundBufferDrainer">
-        <task:scheduled ref="outBuffer" method="drain" fixed-delay="#{outBufferInterval}"/>
+        <task:scheduled ref="outBuffer" method="drain" fixed-delay="#{T(org.apache.commons.lang3.StringUtils).isNotEmpty(systemProperties['outbuffer.drain.period']) ? systemProperties['outbuffer.drain.period'] : '100'}"/>
     </task:scheduled-tasks>
 
     <!--Session timeout job-->

--- a/package/score-worker/src/main/resources/META-INF/spring/score/context/scoreWorkerSchedulerContext.xml
+++ b/package/score-worker/src/main/resources/META-INF/spring/score/context/scoreWorkerSchedulerContext.xml
@@ -23,7 +23,8 @@
     -->
     <task:scheduler id="scoreOutboundBufferDrainer" pool-size="1" />
     <task:scheduled-tasks scheduler="scoreOutboundBufferDrainer">
-        <task:scheduled ref="outBuffer" method="drain" fixed-delay="#{T(org.apache.commons.lang3.StringUtils).isNotEmpty(systemProperties['outbuffer.drain.period']) ? systemProperties['outbuffer.drain.period'] : '100'}"/>
+        <task:scheduled ref="outBuffer" method="drain"
+                fixed-delay="#{T(org.apache.commons.lang3.StringUtils).isNotEmpty(systemProperties['outbuffer.drain.period']) ? systemProperties['outbuffer.drain.period'] : '100'}"/>
     </task:scheduled-tasks>
 
     <!--Session timeout job-->


### PR DESCRIPTION
Introduce system property `-Doutbuffer.drain.period=250` to be able to configure the the outbuffer draining period in miliseconds.

Signed-off-by: Lucian Musca lucian-cristian.musca@microfocus.com