### PR TITLE
added CONCURRENT_HOURLY license type

### DIFF
--- a/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/score/facade/execution/LicenseType.java
+++ b/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/score/facade/execution/LicenseType.java
@@ -19,7 +19,8 @@ public enum LicenseType {
     UNDEFINED(-1),
     CONCURRENT_BOT(0),
     HOURLY(1),
-    INSTANT_ON(2);
+    INSTANT_ON(2),
+    CONCURRENT_HOURLY(3);
 
     private final int code;
 


### PR DESCRIPTION
Added new license type for hourly fallback. It means that if no concurrent is available for the selected flow then run it with hourly .
Signed-off-by: Igor Vorobiov igor.vorobiov@microfocus.com