### PR TITLE
Evaluate python expression even if it contains 'newline' character

### DIFF
--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutor.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutor.java
@@ -100,7 +100,7 @@ public class ExternalPythonExecutor {
         try {
             String pythonPath = checkPythonPath();
             tempEvalEnvironment = generateTempResourcesForEval();
-            String payload = generatePayloadForEval(expression, prepareEnvironmentScript, context);
+            String payload = generatePayloadForEval(expression.replace("\n", ""), prepareEnvironmentScript, context);
             addFilePermissions(tempEvalEnvironment.parentFolder);
 
             return runPythonEvalProcess(pythonPath, payload, tempEvalEnvironment, context);

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutor.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutor.java
@@ -100,7 +100,7 @@ public class ExternalPythonExecutor {
         try {
             String pythonPath = checkPythonPath();
             tempEvalEnvironment = generateTempResourcesForEval();
-            String payload = generatePayloadForEval(expression.replace("\n", ""), prepareEnvironmentScript, context);
+            String payload = generatePayloadForEval(expression.replaceAll("[\\n\\r]", ""), prepareEnvironmentScript, context);
             addFilePermissions(tempEvalEnvironment.parentFolder);
 
             return runPythonEvalProcess(pythonPath, payload, tempEvalEnvironment, context);

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutor.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutor.java
@@ -100,7 +100,7 @@ public class ExternalPythonExecutor {
         try {
             String pythonPath = checkPythonPath();
             tempEvalEnvironment = generateTempResourcesForEval();
-            String payload = generatePayloadForEval(expression.replaceAll("[\\n\\r]", ""), prepareEnvironmentScript, context);
+            String payload = generatePayloadForEval(expression, prepareEnvironmentScript, context);
             addFilePermissions(tempEvalEnvironment.parentFolder);
 
             return runPythonEvalProcess(pythonPath, payload, tempEvalEnvironment, context);
@@ -269,7 +269,7 @@ public class ExternalPythonExecutor {
     private String generatePayloadForEval(String expression, String prepareEnvironmentScript,
                                        Map<String, Serializable> context) throws JsonProcessingException {
         HashMap<String, Serializable> payload = new HashMap<>(4);
-        payload.put("expression", expression);
+        payload.put("expression", StringUtils.replaceChars(expression, "\n\r", " "));
         payload.put("envSetup", prepareEnvironmentScript);
         payload.put("context", (Serializable) context);
         return objectMapper.writeValueAsString(payload);


### PR DESCRIPTION
Evaluate python expression even if they contain 'newline' character.
Replace 'newline' characters ('\n') with empty string in order to be able to evaluate python expressions written on multiple lines.