### PR TITLE
allow single quotes in deserialization

### DIFF
--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutor.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutor.java
@@ -15,6 +15,8 @@
  */
 package io.cloudslang.runtime.impl.python.external;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -48,6 +50,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -70,8 +73,13 @@ public class ExternalPythonExecutor {
     private static final long EXECUTION_TIMEOUT = Long.getLong("python.timeout", 30);
     private static final String PYTHON_FILENAME_SCRIPT_EXTENSION = ".py\"";
     private static final int PYTHON_FILENAME_DELIMITERS = 6;
+    private static final ObjectMapper objectMapper;
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    static {
+        JsonFactory factory = new JsonFactory();
+        factory.enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES);
+        objectMapper = new ObjectMapper(factory);
+    }
 
     public PythonExecutionResult exec(String script, Map<String, Serializable> inputs) {
         TempExecutionEnvironment tempExecutionEnvironment = null;
@@ -208,7 +216,7 @@ public class ExternalPythonExecutor {
             case INTEGER:
                 return Integer.valueOf(results.getReturnResult());
             case LIST:
-                return (Serializable) objectMapper.readValue(results.getReturnResult(), new TypeReference<List<String>>(){});
+                return objectMapper.readValue(results.getReturnResult(), new TypeReference<ArrayList<Serializable>>(){});
             default:
                 return results.getReturnResult();
         }

--- a/runtime-management/runtime-management-impl/src/main/resources/eval.py
+++ b/runtime-management/runtime-management-impl/src/main/resources/eval.py
@@ -112,18 +112,18 @@ class PythonAgentExecutor(object):
                 return_type = type(expr_result).__name__
 
                 if return_type == 'range':
-                    expr_result = str(list(map(str, expr_result))).replace("\'", "\"")
+                    expr_result = str(list(map(str, expr_result)))
                     return_type = 'list'
 
                 elif return_type == 'list':
-                    expr_result = str(expr_result).replace("\'", "\"")
+                    expr_result = str(expr_result)
 
                 elif return_type in ['map',  'tuple',  'set']:
-                    expr_result = str(list(expr_result)).replace("\'", "\"")
+                    expr_result = str(list(expr_result))
                     return_type = 'list'
 
                 elif return_type == 'dict':
-                    expr_result = str(list(expr_result.keys())).replace("\'", "\"")
+                    expr_result = str(list(expr_result.keys()))
                     return_type = 'list'
 
                 elif return_type == '_Element':


### PR DESCRIPTION
lists having quotes inside elements were causing execution to fail because they couldn't be parsed: ["temp", "'tem,p'"]

Signed-off-by: Adriana Corui adriana-natalia.corui@microfocus.com

