### PR TITLE
Outbuffer performance improvements

### DIFF
--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
@@ -147,7 +147,7 @@ public class OutboundBufferImpl implements OutboundBuffer, WorkerRecoveryListene
 
     private void drainInternal(HashMap<String, ArrayList<Message>> bufferToDrain) {
         int bulkWeight = 0;
-        List<Message> bulk = new ArrayList<>();
+        List<Message> bulk = new ArrayList<>(bufferToDrain.size());
         try {
             for (ArrayList<Message> value : bufferToDrain.values()) {
                 List<Message> optimizedList = value.get(0).shrink(value);

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
@@ -104,13 +104,6 @@ public class OutboundBufferImpl implements OutboundBuffer, WorkerRecoveryListene
             } else {
                 oldValue.add(messageToAdd);
             }
-//            buffer.merge(executionId, mutableListWrapper, (oldValue, newValue) -> {
-//                // Guaranteed that oldValue is not null, since otherwise newValue will be assigned directly
-//                // Guaranteed that newValue has 1 element only
-//                // Add at end to keep order of events across an execution id
-//                oldValue.add(newValue.get(0));
-//                return oldValue;
-//            });
             currentWeight += messageToAddWeight;
         } catch (InterruptedException ex) {
             logger.warn("Buffer put action was interrupted", ex);
@@ -149,11 +142,7 @@ public class OutboundBufferImpl implements OutboundBuffer, WorkerRecoveryListene
                 }
                 syncManager.waitForMessages();
             }
-
-            if (logger.isDebugEnabled()) {
-                logger.debug("buffer is going to be drained. " + getStatus());
-            }
-
+            // Switch to the new buffer and drain old buffer on the same scheduled threadpool thread
             bufferToDrain = buffer;
             buffer = getInitialBuffer();
             currentWeight = 0;

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
@@ -88,8 +88,6 @@ public class OutboundBufferImpl implements OutboundBuffer, WorkerRecoveryListene
         final Message messageToAdd = validateAndGetMessageToPut(messages);
         final int messageToAddWeight = messageToAdd.getWeight();
         final String executionId = messageToAdd.getId();
-        final ArrayList<Message> mutableListWrapper = getMutableListWrapper(messageToAdd);
-
         try {
             syncManager.startPutMessages();
             // We need to check if the current thread was interrupted while waiting for the lock (ExecutionThread or InBufferThread in ackMessages)
@@ -102,9 +100,9 @@ public class OutboundBufferImpl implements OutboundBuffer, WorkerRecoveryListene
             // Put message into the buffer
             ArrayList<Message> oldValue = buffer.get(executionId);
             if (oldValue == null) {
-                buffer.put(executionId, mutableListWrapper);
+                buffer.put(executionId, getMutableListWrapper(messageToAdd));
             } else {
-                oldValue.add(mutableListWrapper.get(0));
+                oldValue.add(messageToAdd);
             }
 //            buffer.merge(executionId, mutableListWrapper, (oldValue, newValue) -> {
 //                // Guaranteed that oldValue is not null, since otherwise newValue will be assigned directly

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
@@ -103,6 +103,7 @@ public class OutboundBufferImpl implements OutboundBuffer, WorkerRecoveryListene
             buffer.merge(executionId, mutableListWrapper, (oldValue, newValue) -> {
                 // Guaranteed that oldValue is not null, since otherwise newValue will be assigned directly
                 // Guaranteed that newValue has 1 element only
+                // Add at end to keep order of events across an execution id
                 oldValue.add(newValue.get(0));
                 return oldValue;
             });
@@ -164,7 +165,7 @@ public class OutboundBufferImpl implements OutboundBuffer, WorkerRecoveryListene
 
     private void drainInternal(HashMap<String, ArrayList<Message>> bufferToDrain) {
         int bulkWeight = 0;
-        List<Message> bulk = new ArrayList<>(bufferToDrain.size());
+        List<Message> bulk = new ArrayList<>();
         try {
             for (ArrayList<Message> value : bufferToDrain.values()) {
                 List<Message> convertedList = expandCompoundMessages(value);

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
@@ -181,6 +181,7 @@ public class OutboundBufferImpl implements OutboundBuffer, WorkerRecoveryListene
                     bulkWeight = 0;
                 }
             }
+            // Drain last bulk if required
             if (!bulk.isEmpty()) {
                 drainBulk(bulk);
             }

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
@@ -100,13 +100,19 @@ public class OutboundBufferImpl implements OutboundBuffer, WorkerRecoveryListene
             }
 
             // Put message into the buffer
-            buffer.merge(executionId, mutableListWrapper, (oldValue, newValue) -> {
-                // Guaranteed that oldValue is not null, since otherwise newValue will be assigned directly
-                // Guaranteed that newValue has 1 element only
-                // Add at end to keep order of events across an execution id
-                oldValue.add(newValue.get(0));
-                return oldValue;
-            });
+            ArrayList<Message> oldValue = buffer.get(executionId);
+            if (oldValue == null) {
+                buffer.put(executionId, mutableListWrapper);
+            } else {
+                oldValue.add(mutableListWrapper.get(0));
+            }
+//            buffer.merge(executionId, mutableListWrapper, (oldValue, newValue) -> {
+//                // Guaranteed that oldValue is not null, since otherwise newValue will be assigned directly
+//                // Guaranteed that newValue has 1 element only
+//                // Add at end to keep order of events across an execution id
+//                oldValue.add(newValue.get(0));
+//                return oldValue;
+//            });
             currentWeight += messageToAddWeight;
         } catch (InterruptedException ex) {
             logger.warn("Buffer put action was interrupted", ex);

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/OutboundBufferImpl.java
@@ -98,7 +98,7 @@ public class OutboundBufferImpl implements OutboundBuffer, WorkerRecoveryListene
                 logger.info("Outbound buffer drained. Finished waiting.");
             }
 
-            // Put message into the buffer
+            // Put message into the buffer, intentionally not using merge function because of extra if
             LinkedList<Message> oldValue = buffer.get(executionId);
             if (oldValue == null) {
                 buffer.put(executionId, getMutableListWrapper(messageToAdd));

--- a/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/services/OutboundBufferTest.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/services/OutboundBufferTest.java
@@ -18,7 +18,6 @@ package io.cloudslang.worker.management.services;
 
 import io.cloudslang.orchestrator.entities.Message;
 import io.cloudslang.orchestrator.services.OrchestratorDispatcherService;
-import junit.framework.Assert;
 import org.apache.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +30,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import static org.mockito.Matchers.argThat;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -39,10 +37,12 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
@@ -113,12 +113,12 @@ public class OutboundBufferTest {
 
 		// wait for that thread to block
 		waitForThreadStateToBe(thread, Thread.State.WAITING);
-		Assert.assertEquals("inserting thread should be in a waiting state when inserting to full buffer", Thread.State.WAITING, thread.getState());
+		assertEquals("inserting thread should be in a waiting state when inserting to full buffer", Thread.State.WAITING, thread.getState());
 
 		// drain the buffer -> will send the first 10 messages and release the blocking thread
 		buffer.drain();
 		waitForThreadStateToBe(thread, Thread.State.TERMINATED);
-		Assert.assertEquals("inserting thread should be in a terminated state after inserting to buffer", Thread.State.TERMINATED, thread.getState());
+		assertEquals("inserting thread should be in a terminated state after inserting to buffer", Thread.State.TERMINATED, thread.getState());
 		thread.join();
 	}
 
@@ -139,7 +139,7 @@ public class OutboundBufferTest {
 
 		// draining the buffer should block since it is empty
 		waitForThreadStateToBe(thread, Thread.State.WAITING);
-		Assert.assertEquals("reading thread should be in a waiting state when inserting to full buffer", Thread.State.WAITING, thread.getState());
+		assertEquals("reading thread should be in a waiting state when inserting to full buffer", Thread.State.WAITING, thread.getState());
 
 		// insert 2 new messages
 		Message[] messages = new Message[]{new DummyMsg1(), new DummyMsg2()};
@@ -147,7 +147,7 @@ public class OutboundBufferTest {
 
 		// thread should be released now
 		waitForThreadStateToBe(thread, Thread.State.TERMINATED);
-		Assert.assertEquals("reading thread should be in a terminated after a message was inserted to the buffer", Thread.State.TERMINATED, thread.getState());
+		assertEquals("reading thread should be in a terminated after a message was inserted to the buffer", Thread.State.TERMINATED, thread.getState());
 
 		thread.join();
         verify(dispatcherService).dispatch((List<? extends Serializable>) argThat(new MessagesSizeMatcher(Arrays.asList(messages))), anyString(), anyString(), anyString());
@@ -253,11 +253,11 @@ public class OutboundBufferTest {
         for (DummyMsg1 message : messages) {
             buffer.put(message);
         }
-        Assert.assertEquals(2,buffer.getSize());
-        Assert.assertEquals(2,buffer.getWeight());
+        assertEquals(1, buffer.getSize());
+        assertEquals(2, buffer.getWeight());
         ((WorkerRecoveryListener)buffer).doRecovery();
-        Assert.assertEquals(0,buffer.getSize());
-        Assert.assertEquals(0,buffer.getWeight());
+        assertEquals(0, buffer.getSize());
+        assertEquals(0, buffer.getWeight());
     }
 
     private class MessagesSizeMatcher extends ArgumentMatcher{


### PR DESCRIPTION
Change the list to a hashmap to avoid grouping to have a a faster optimize of messages.
Signed-off-by: Lucian Musca lucian-cristian.musca@microfocus.com