### PR TITLE
Outbound buffer capacity

### DIFF
--- a/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/services/OutboundBufferTest.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/test/java/io/cloudslang/worker/management/services/OutboundBufferTest.java
@@ -50,197 +50,200 @@ import static org.mockito.Mockito.verify;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 public class OutboundBufferTest {
-	private final Logger logger = Logger.getLogger(getClass());
 
-	private static final int MAX_BUFFER_WEIGHT = 10;
-	private static final int MAX_BULK_WEIGHT = 3;
+    private final Logger logger = Logger.getLogger(getClass());
 
-	@Autowired
-	private WorkerRecoveryManager recoveryManager;
+    private static final int MAX_BUFFER_WEIGHT = 10;
+    private static final int MAX_BULK_WEIGHT = 3;
 
-	@Autowired
-	private OutboundBuffer buffer;
+    @Autowired
+    private WorkerRecoveryManager recoveryManager;
 
-	@Autowired
-	private OrchestratorDispatcherService dispatcherService;
+    @Autowired
+    private OutboundBuffer buffer;
 
-	@Before
-	public void setUp() {
-		((WorkerRecoveryListener)buffer).doRecovery();
-		reset(recoveryManager, dispatcherService);
-	}
+    @Autowired
+    private OrchestratorDispatcherService dispatcherService;
 
-	/**
-	 * Makes sure the buffer aggregates messages and dispatches them in bulk
-	 */
-	@Test
-	public void testAggregation() throws InterruptedException {
-		List<DummyMsg1> messages = Arrays.asList(new DummyMsg1(), new DummyMsg1());
+    @Before
+    public void setUp() {
+        ((WorkerRecoveryListener) buffer).doRecovery();
+        reset(recoveryManager, dispatcherService);
+    }
 
-		for (DummyMsg1 message : messages) {
-			buffer.put(message);
-		}
+    /**
+     * Makes sure the buffer aggregates messages and dispatches them in bulk
+     */
+    @Test
+    public void testAggregation() throws InterruptedException {
+        List<DummyMsg1> messages = Arrays.asList(new DummyMsg1(), new DummyMsg1());
 
-		buffer.drain();
-        verify(dispatcherService).dispatch((List<? extends Serializable>) argThat(new MessagesSizeMatcher(messages)), anyString(), anyString(),anyString());
-	}
+        for (DummyMsg1 message : messages) {
+            buffer.put(message);
+        }
 
-	/**
-	 * checks that when inserting messages to a full buffer,
-	 * the inserting thread will block until the buffer is emptied
-	 *
-	 * @throws InterruptedException
-	 */
-	@Test
-	public void testProducerBlocking() throws InterruptedException {
-		// buffer capacity is 10, put messages in it until it is full
-		while (buffer.getWeight() < MAX_BUFFER_WEIGHT) {
-			buffer.put(new DummyMsg1());
-		}
+        buffer.drain();
+        verify(dispatcherService)
+                .dispatch((List<? extends Serializable>) argThat(new MessagesSizeMatcher(messages)), anyString(),
+                        anyString(), anyString());
+    }
 
-		// the next insert to buffer will block because it's full, do it on a different thread
-		Thread thread = new Thread(new Runnable() {
-			@Override
-			public void run() {
-                try {
-                    buffer.put(new DummyMsg1());
-                } catch (InterruptedException e) {
-                    //ignore
-                }
+    /**
+     * checks that when inserting messages to a full buffer, the inserting thread will block until the buffer is
+     * emptied
+     */
+    @Test
+    public void testProducerBlocking() throws InterruptedException {
+        // buffer capacity is 10, put messages in it until it is full
+        while (buffer.getWeight() < MAX_BUFFER_WEIGHT) {
+            buffer.put(new DummyMsg1());
+        }
+
+        // the next insert to buffer will block because it's full, do it on a different thread
+        Thread thread = new Thread(() -> {
+			try {
+				buffer.put(new DummyMsg1());
+			} catch (InterruptedException e) {
+				//ignore
+			}
+		});
+        thread.start();
+
+        // wait for that thread to block
+        waitForThreadStateToBe(thread, Thread.State.WAITING);
+        assertEquals("inserting thread should be in a waiting state when inserting to full buffer",
+                Thread.State.WAITING, thread.getState());
+
+        // drain the buffer -> will send the first 10 messages and release the blocking thread
+        buffer.drain();
+        waitForThreadStateToBe(thread, Thread.State.TERMINATED);
+        assertEquals("inserting thread should be in a terminated state after inserting to buffer",
+                Thread.State.TERMINATED, thread.getState());
+        thread.join();
+    }
+
+    /**
+     * Checks that the buffer will block when having no messages and continues when the first message arrives
+     */
+    @Test
+    public void testConsumerBlocking() throws InterruptedException {
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                buffer.drain();
             }
-		});
-		thread.start();
+        });
+        thread.start();
 
-		// wait for that thread to block
-		waitForThreadStateToBe(thread, Thread.State.WAITING);
-		assertEquals("inserting thread should be in a waiting state when inserting to full buffer", Thread.State.WAITING, thread.getState());
+        // draining the buffer should block since it is empty
+        waitForThreadStateToBe(thread, Thread.State.WAITING);
+        assertEquals("reading thread should be in a waiting state when inserting to full buffer", Thread.State.WAITING,
+                thread.getState());
 
-		// drain the buffer -> will send the first 10 messages and release the blocking thread
-		buffer.drain();
-		waitForThreadStateToBe(thread, Thread.State.TERMINATED);
-		assertEquals("inserting thread should be in a terminated state after inserting to buffer", Thread.State.TERMINATED, thread.getState());
-		thread.join();
-	}
+        // insert 2 new messages
+        Message[] messages = new Message[]{new DummyMsg1(), new DummyMsg2()};
+        buffer.put(messages);
 
-	/**
-	 * Checks that the buffer will block when having no messages and continues when the first message arrives
-	 *
-	 * @throws InterruptedException
-	 */
-	@Test
-	public void testConsumerBlocking() throws InterruptedException {
-		Thread thread = new Thread(new Runnable() {
-			@Override
-			public void run() {
-				buffer.drain();
+        // thread should be released now
+        waitForThreadStateToBe(thread, Thread.State.TERMINATED);
+        assertEquals("reading thread should be in a terminated after a message was inserted to the buffer",
+                Thread.State.TERMINATED, thread.getState());
+
+        thread.join();
+        verify(dispatcherService)
+                .dispatch((List<? extends Serializable>) argThat(new MessagesSizeMatcher(Arrays.asList(messages))),
+                        anyString(), anyString(), anyString());
+    }
+
+
+    private void waitForThreadStateToBe(Thread thread, Thread.State state) throws InterruptedException {
+        int waitCount = 0;
+        while (!thread.getState().equals(state) && waitCount <= 20) {
+            Thread.sleep(50);
+            waitCount++;
+        }
+    }
+
+    @Test
+    public void longevityTest() throws InterruptedException {
+        int THREADS_NUM = 5;
+        long CHECK_DURATION = 5 * 1000L;
+        long INFO_FREQUENCY = 2 * 1000L;
+
+        final AtomicBoolean run = new AtomicBoolean(true);
+        final CountDownLatch latch = new CountDownLatch(THREADS_NUM + 1);
+
+        for (int i = 1; i <= THREADS_NUM; i++) {
+            final int index = i;
+            new Thread(new Runnable() {
+                private final Class<? extends Message> messageClass =
+                        (index % 2) != 0 ? DummyMsg1.class : DummyMsg2.class;
+
+                @Override
+                public void run() {
+                    int counter = 0;
+                    try {
+                        logger.debug("started, will generate messages of " + messageClass.getSimpleName());
+
+                        while (run.get()) {
+                            buffer.put(messageClass.newInstance());
+                            counter++;
+                            Thread.sleep(5L);
+                        }
+                        logger.debug("thread finished. processed " + counter + " messages");
+                    } catch (Exception ex) {
+                        logger.error("thread finished", ex);
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+            }, "T-" + i).start();
+        }
+
+        final DrainStatistics statistics = new DrainStatistics();
+        //noinspection unchecked
+        doAnswer((Answer<Object>) invocation -> {
+			@SuppressWarnings("unchecked") List<Message> messages = (List<Message>) invocation.getArguments()[0];
+			int weight = 0;
+			for (Message message : messages) {
+				weight += message.getWeight();
 			}
-		});
-		thread.start();
-
-		// draining the buffer should block since it is empty
-		waitForThreadStateToBe(thread, Thread.State.WAITING);
-		assertEquals("reading thread should be in a waiting state when inserting to full buffer", Thread.State.WAITING, thread.getState());
-
-		// insert 2 new messages
-		Message[] messages = new Message[]{new DummyMsg1(), new DummyMsg2()};
-		buffer.put(messages);
-
-		// thread should be released now
-		waitForThreadStateToBe(thread, Thread.State.TERMINATED);
-		assertEquals("reading thread should be in a terminated after a message was inserted to the buffer", Thread.State.TERMINATED, thread.getState());
-
-		thread.join();
-        verify(dispatcherService).dispatch((List<? extends Serializable>) argThat(new MessagesSizeMatcher(Arrays.asList(messages))), anyString(), anyString(), anyString());
-	}
-
-
-
-	private void waitForThreadStateToBe(Thread thread, Thread.State state) throws InterruptedException {
-		int waitCount = 0;
-		while (!thread.getState().equals(state) && waitCount <= 20) {
-			Thread.sleep(50);
-			waitCount++;
-		}
-	}
-
-	@Test
-	public void longevityTest() throws InterruptedException {
-		int THREADS_NUM = 5;
-		long CHECK_DURATION = 5*1000L;
-		long INFO_FREQUENCY = 2*1000L;
-
-		final AtomicBoolean run = new AtomicBoolean(true);
-		final CountDownLatch latch = new CountDownLatch(THREADS_NUM+1);
-
-		for (int i=1; i<=THREADS_NUM; i++){
-			final int index = i;
-			new Thread(new Runnable() {
-				private final Class<? extends Message> messageClass = (index%2)!=0? DummyMsg1.class: DummyMsg2.class;
-
-				@Override
-				public void run() {
-					int counter=0;
-					try {
-						logger.debug("started, will generate messages of " + messageClass.getSimpleName());
-
-						while (run.get()){
-							buffer.put(messageClass.newInstance());
-							counter++;
-							Thread.sleep(5L);
-						}
-						logger.debug("thread finished. processed " + counter + " messages");
-					} catch (Exception ex) {
-						logger.error("thread finished", ex);
-					} finally {
-						latch.countDown();
-					}
-				}
-			}, "T-"+i).start();
-		}
-
-		final DrainStatistics statistics = new DrainStatistics();
-		//noinspection unchecked
-		doAnswer(new Answer<Object>() {
-			@Override
-			public Object answer(InvocationOnMock invocation) throws Throwable {
-				@SuppressWarnings("unchecked") List<Message> messages = (List<Message>) invocation.getArguments()[0];
-				int weight = 0;
-				for (Message message : messages) weight += message.getWeight();
-				statistics.add(messages.size(), weight);
-				return null;
-			}
+			statistics.add(messages.size(), weight);
+			return null;
 		}).when(dispatcherService).dispatch(anyList(), anyString(), anyString(), anyString());
 
-		new Thread(new Runnable() {
-			@Override
-			public void run() {
-				try {
-					logger.debug("started");
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    logger.debug("started");
 
-					while (run.get()){
+                    while (run.get()) {
+                        buffer.drain();
+                        Thread.sleep(30L);
+                    }
+
+					while (buffer.getSize() > 0) {
 						buffer.drain();
-						Thread.sleep(30L);
 					}
+                } catch (Exception ex) {
+                    logger.error("thread finished", ex);
+                } finally {
+                    latch.countDown();
+                }
+            }
+        }, "T-D").start();
 
-					while (buffer.getSize() > 0) buffer.drain();
-				} catch (Exception ex) {
-					logger.error("thread finished", ex);
-				} finally {
-					latch.countDown();
-				}
-			}
-		}, "T-D").start();
+        long t = System.currentTimeMillis();
+        while (System.currentTimeMillis() - t < CHECK_DURATION) {
+            Thread.sleep(INFO_FREQUENCY);
+            logger.debug(buffer.getStatus());
+        }
+        run.set(false);
+        latch.await();
 
-		long t = System.currentTimeMillis();
-		while (System.currentTimeMillis()-t < CHECK_DURATION){
-			Thread.sleep(INFO_FREQUENCY);
-			logger.debug(buffer.getStatus());
-		}
-		run.set(false);
-		latch.await();
-
-		System.out.println("Drain statistics: " + statistics.report());
-	}
+        System.out.println("Drain statistics: " + statistics.report());
+    }
 
 
     /**
@@ -255,12 +258,13 @@ public class OutboundBufferTest {
         }
         assertEquals(1, buffer.getSize());
         assertEquals(2, buffer.getWeight());
-        ((WorkerRecoveryListener)buffer).doRecovery();
+        ((WorkerRecoveryListener) buffer).doRecovery();
         assertEquals(0, buffer.getSize());
         assertEquals(0, buffer.getWeight());
     }
 
-    private class MessagesSizeMatcher extends ArgumentMatcher{
+    private class MessagesSizeMatcher extends ArgumentMatcher {
+
         List messages;
 
         public MessagesSizeMatcher(List val) {
@@ -269,9 +273,9 @@ public class OutboundBufferTest {
 
         @Override
         public boolean matches(Object argument) {
-            if(argument instanceof List){
-                List listConverted = (List)argument;
-                if(listConverted.size() ==  messages.size()){
+            if (argument instanceof List) {
+                List listConverted = (List) argument;
+                if (listConverted.size() == messages.size()) {
                     return true;
                 }
             }
@@ -279,24 +283,27 @@ public class OutboundBufferTest {
         }
     }
 
-    static class DrainStatistics{
+    static class DrainStatistics {
+
         private int counter;
         private int size;
         private int weight;
 
-        public void add(int size, int weight){
+        public void add(int size, int weight) {
             counter++;
-            this.size+=size;
-            this.weight+=weight;
+            this.size += size;
+            this.weight += weight;
         }
 
-        public String report(){
-            return "Buffer has sent " + counter + " bulks, avg(size): " + size/counter + ", avg(weight): " + weight/counter + ", total messages: " + size;
+        public String report() {
+            return "Buffer has sent " + counter + " bulks, avg(size): " + size / counter + ", avg(weight): "
+                    + weight / counter + ", total messages: " + size;
         }
     }
 
 
     static class DummyMsg1 implements Message {
+
         public int getWeight() {
             return 1;
         }
@@ -311,6 +318,7 @@ public class OutboundBufferTest {
     }
 
     static class DummyMsg2 implements Message {
+
         public int getWeight() {
             return 2;
         }
@@ -326,41 +334,47 @@ public class OutboundBufferTest {
 
     @Configuration
     static class config {
-        static{
+
+        static {
             System.setProperty("out.buffer.max.buffer.weight", String.valueOf(MAX_BUFFER_WEIGHT));
             System.setProperty("out.buffer.max.bulk.weight", String.valueOf(MAX_BULK_WEIGHT));
         }
 
-		@Bean
-		public WorkerRecoveryManager workerRecoveryManager() {
-			return mock(WorkerRecoveryManager.class);
-		}
-
-		@Bean
-		OrchestratorDispatcherService orchestratorDispatcherService(){
-			return mock(OrchestratorDispatcherService.class);
-		}
+        @Bean
+        public WorkerRecoveryManager workerRecoveryManager() {
+            return mock(WorkerRecoveryManager.class);
+        }
 
         @Bean
-        SynchronizationManager synchronizationManager(){
+        OrchestratorDispatcherService orchestratorDispatcherService() {
+            return mock(OrchestratorDispatcherService.class);
+        }
+
+        @Bean
+        SynchronizationManager synchronizationManager() {
             return new SynchronizationManagerImpl();
         }
 
-		@Bean
-		public RetryTemplate retryTemplate() {
-			return new RetryTemplate();
-		}
-
-		@Bean
-		public OutboundBuffer outboundBuffer() {
-			return new OutboundBufferImpl();
+        @Bean
+        public RetryTemplate retryTemplate() {
+            return new RetryTemplate();
         }
 
         @Bean
-        String workerUuid() {
+        public OutboundBuffer outboundBuffer() {
+            return new OutboundBufferImpl();
+        }
+
+        @Bean
+        public String workerUuid() {
             return "1234";
         }
 
-	}
+        @Bean
+        public Integer numberOfExecutionThreads() {
+            return 10;
+        }
+
+    }
 
 }


### PR DESCRIPTION
Outbound buffer capacity is now configurable from system property `out.buffer.entries`, with default value taken from the number of execution threads.

Signed-off-by: Lucian Musca lucian-cristian.musca@microfocus.com