### PR TITLE
Optimize merged configuration

### DIFF
--- a/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/services/WorkerNodeService.java
+++ b/engine/node/score-node-api/src/main/java/io/cloudslang/engine/node/services/WorkerNodeService.java
@@ -22,11 +22,11 @@ import io.cloudslang.engine.node.entities.WorkerNode;
 import io.cloudslang.score.api.nodes.WorkerStatus;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
- * Created by IntelliJ IDEA.
- * User:
- * Date: 08/11/12
+ * Created by IntelliJ IDEA. User: Date: 08/11/12
  * <p>
  * A service responsible for handling a worker node record
  */
@@ -35,8 +35,7 @@ public interface WorkerNodeService {
     /**
      * Update the Worker Node entity with the current ack version for the keep alive mechanism
      *
-     * @param uuid worker's unique identifier
-     *             Maintained for backward compatibility only
+     * @param uuid worker's unique identifier Maintained for backward compatibility only
      * @return the worker's recovery version (WRV)
      */
     String keepAlive(String uuid);
@@ -52,9 +51,9 @@ public interface WorkerNodeService {
     /**
      * Create a new worker
      *
-     * @param uuid       worker's unique identifier
-     * @param password   worker's password
-     * @param hostName   worker's host
+     * @param uuid worker's unique identifier
+     * @param password worker's password
+     * @param hostName worker's host
      * @param installDir worker's installation directory
      */
     void create(String uuid, String password, String hostName, String installDir);
@@ -76,16 +75,16 @@ public interface WorkerNodeService {
     /**
      * Reads all of the workers that are not marked with the IS_DELETED flag
      *
-     * @return a List of {@link io.cloudslang.engine.node.entities.WorkerNode} that are ont marked with
-     * the IS_DELETED flag
+     * @return a List of {@link io.cloudslang.engine.node.entities.WorkerNode} that are ont marked with the IS_DELETED
+     * flag
      */
     List<WorkerNode> readAllNotDeletedWorkers();
 
     /**
      * Notifies the orchestrator that a worker went up
      *
-     * @param uuid      the the uuid of the worker that went up
-     * @param version   the version of the worker that went up
+     * @param uuid the the uuid of the worker that went up
+     * @param version the version of the worker that went up
      * @param versionId the versionId of the worker that went up
      * @return a String of the current recovery version of the worker
      */
@@ -109,9 +108,6 @@ public interface WorkerNodeService {
 
     /**
      * Returns active status of the worker according to the worker UUID
-     *
-     * @param workerUuid
-     * @return
      */
     boolean isActive(String workerUuid);
 
@@ -141,8 +137,8 @@ public interface WorkerNodeService {
      * read all worker that there activation status is as a given status
      *
      * @param isActive the requested activation status.
-     * @return a List of all {@link io.cloudslang.engine.node.entities.WorkerNode} the their
-     * activation status is as the given status
+     * @return a List of all {@link io.cloudslang.engine.node.entities.WorkerNode} the their activation status is as the
+     * given status
      */
     List<WorkerNode> readWorkersByActivation(boolean isActive);
 
@@ -163,9 +159,9 @@ public interface WorkerNodeService {
     /**
      * updates the environment params of a given worker
      *
-     * @param uuid          the uuid of the worker to update
-     * @param os            the operating system the worker is running on
-     * @param jvm           the jvm version the worker is running on
+     * @param uuid the uuid of the worker to update
+     * @param os the operating system the worker is running on
+     * @param jvm the jvm version the worker is running on
      * @param dotNetVersion the dot-net version the worker is using
      */
     void updateEnvironmentParams(String uuid, String os, String jvm, String dotNetVersion);
@@ -173,7 +169,7 @@ public interface WorkerNodeService {
     /**
      * updates the status of a given worker
      *
-     * @param uuid   the uuid of the worker to update
+     * @param uuid the uuid of the worker to update
      * @param status the status to update the given worker to
      */
     void updateStatus(String uuid, WorkerStatus status);
@@ -181,7 +177,7 @@ public interface WorkerNodeService {
     /**
      * updates the status of a given worker in a separate transaction
      *
-     * @param uuid   the uuid of the worker to update
+     * @param uuid the uuid of the worker to update
      * @param status the status to update the given worker to
      */
     void updateStatusInSeparateTransaction(String uuid, WorkerStatus status);
@@ -189,7 +185,7 @@ public interface WorkerNodeService {
     /**
      * updates the migration password field of a worker node
      *
-     * @param uuid   the uuid of the worker to update
+     * @param uuid the uuid of the worker to update
      * @param password the migrated password to be used
      */
     void migratePassword(String uuid, String password);
@@ -212,7 +208,7 @@ public interface WorkerNodeService {
     /**
      * updates the groups associated with a worker
      *
-     * @param uuid       the uuid of the worker to update groups for
+     * @param uuid the uuid of the worker to update groups for
      * @param groupNames the groups to associate with the worker
      */
     void updateWorkerGroups(String uuid, String... groupNames);
@@ -221,8 +217,8 @@ public interface WorkerNodeService {
      * Reads all of the worker that are active and running and their groups
      *
      * @param versionId - the version of workers
-     * @return A {@link com.google.common.collect.Multimap} of the
-     * active and running workers in specific version and their groups
+     * @return A {@link com.google.common.collect.Multimap} of the active and running workers in specific version and
+     * their groups
      */
     Multimap<String, String> readGroupWorkersMapActiveAndRunningAndVersion(String versionId);
 
@@ -230,7 +226,7 @@ public interface WorkerNodeService {
      * adds group to be associated with a worker
      *
      * @param workerUuid the uuid of the worker to associate the group to
-     * @param group      the group to associate with the worker
+     * @param group the group to associate with the worker
      */
     void addGroupToWorker(String workerUuid, String group);
 
@@ -238,7 +234,7 @@ public interface WorkerNodeService {
      * removes a group association with a worker
      *
      * @param workerUuid the uuid of the worker to remove the group association from
-     * @param group      the group to remove its association from the worker
+     * @param group the group to remove its association from the worker
      */
     void removeGroupFromWorker(String workerUuid, String group);
 
@@ -262,9 +258,14 @@ public interface WorkerNodeService {
      * updates the worker recovery version of a given worker
      *
      * @param workerUuid the uuid of the worker to update
-     * @param wrv        the new worker recovery version
+     * @param wrv the new worker recovery version
      */
     void updateWRV(String workerUuid, String wrv);
+
+    /**
+     * Retrieves the worker and worker groups as a map
+     */
+    Map<String, Set<String>> readWorkerGroupsMap();
 
     /**
      * Read all workers uuids
@@ -277,8 +278,8 @@ public interface WorkerNodeService {
      * updates the worker version of a given worker
      *
      * @param workerUuid the uuid of the worker to update
-     * @param version    the worker's version
-     * @param versionId  comparable worker's version
+     * @param version the worker's version
+     * @param versionId comparable worker's version
      */
     void updateVersion(String workerUuid, String version, String versionId);
 }

--- a/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/entities/MergedConfigurationDataContainer.java
+++ b/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/entities/MergedConfigurationDataContainer.java
@@ -19,14 +19,26 @@ package io.cloudslang.orchestrator.entities;
 import java.io.Serializable;
 import java.util.Set;
 
+import static java.util.Collections.emptySet;
+
 
 public class MergedConfigurationDataContainer implements Serializable {
 
-    private volatile Set<Long> cancelledExecutions;
-    private volatile Set<String> pausedExecutions;
-    private volatile Set<String> workerGroups;
+    private Set<Long> cancelledExecutions;
+    private Set<String> pausedExecutions;
+    private Set<String> workerGroups;
 
     public MergedConfigurationDataContainer() {
+        this.cancelledExecutions = emptySet();
+        this.pausedExecutions = emptySet();
+        this.workerGroups = emptySet();
+    }
+
+    public MergedConfigurationDataContainer(Set<Long> cancelledExecutions, Set<String> pausedExecutions,
+            Set<String> workerGroups) {
+        this.cancelledExecutions = cancelledExecutions;
+        this.pausedExecutions = pausedExecutions;
+        this.workerGroups = workerGroups;
     }
 
     public Set<Long> getCancelledExecutions() {
@@ -52,5 +64,4 @@ public class MergedConfigurationDataContainer implements Serializable {
     public void setWorkerGroups(Set<String> workerGroups) {
         this.workerGroups = workerGroups;
     }
-
 }

--- a/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/PauseResumeService.java
+++ b/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/PauseResumeService.java
@@ -16,31 +16,23 @@
 
 package io.cloudslang.orchestrator.services;
 
+import io.cloudslang.score.facade.entities.Execution;
 import io.cloudslang.score.facade.execution.ExecutionSummary;
 import io.cloudslang.score.facade.execution.PauseReason;
-import io.cloudslang.score.facade.entities.Execution;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * Created with IntelliJ IDEA.
- * User: kravtsov
- * Date: 17/12/12
- * Time: 15:34
- */
 public interface PauseResumeService {
 
     /**
      * Pauses execution with type PENDING_PAUSE
      *
      * @param executionId id of the execution
-     * @param branchId    id of the branch of the execution we want to pause
-     * @param reason      the pause reason
+     * @param branchId id of the branch of the execution we want to pause
+     * @param reason the pause reason
      * @return paused execution id but in case the execution is already paused then return null
      */
     Long pauseExecution(Long executionId, String branchId, PauseReason reason);
@@ -65,8 +57,8 @@ public interface PauseResumeService {
      * Resumes execution and puts it back to execution queue
      *
      * @param executionId id of the paused execution we want to resume
-     * @param branchId    id of the branch of the execution we want to resume
-     * @param map         the values to run with
+     * @param branchId id of the branch of the execution we want to resume
+     * @param map the values to run with
      */
     void resumeExecution(Long executionId, String branchId, Map<String, Serializable> map);
 
@@ -74,31 +66,38 @@ public interface PauseResumeService {
      * Persists Execution object to the DB
      *
      * @param executionId - execution id
-     * @param branchId    - branch id if it is parallel lane
-     * @param execution   - object to persist
+     * @param branchId - branch id if it is parallel lane
+     * @param execution - object to persist
      * @return the pause reason of the paused execution
      */
     PauseReason writeExecutionObject(Long executionId, String branchId, Execution execution);
 
     /**
-     * Returns list of strings: each one of form: executionId:branchId
+     * Uses caching Returns list of strings: each one of form: executionId:branchId
      *
      * @return list of execution & branch ids of all the paused branches
      */
     Set<String> readAllPausedExecutionBranchIds();
 
     /**
+     * Does not use caching Returns list of strings: each one of form: executionId:branchId
+     *
+     * @return list of execution & branch ids of all the paused branches
+     */
+    Set<String> readAllPausedExecutionBranchIdsNoCache();
+
+    /**
      * Returns the execution if its status is Paused*. Otherwise returns null.
      *
      * @param executionId id of the execution
-     * @param branchId    id of the branch
+     * @param branchId id of the branch
      * @return the execution if its status is Paused*. Otherwise returns null.
      */
     ExecutionSummary readPausedExecution(Long executionId, String branchId);
 
     /**
-     * Get a list of all pause id's that are relevant to an execution,
-     * there could be many because of different lanes that can be paused
+     * Get a list of all pause id's that are relevant to an execution, there could be many because of different lanes
+     * that can be paused
      *
      * @param executionId th execution id in question
      * @return a list of all current pauses id relevant

--- a/engine/orchestrator/score-orchestrator-impl/pom.xml
+++ b/engine/orchestrator/score-orchestrator-impl/pom.xml
@@ -104,6 +104,11 @@
             <artifactId>score-orchestrator-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
         <!-- end of engine artifacts -->
         <!-- test artifacts -->
         <dependency>

--- a/engine/orchestrator/score-orchestrator-impl/pom.xml
+++ b/engine/orchestrator/score-orchestrator-impl/pom.xml
@@ -160,5 +160,10 @@
             <artifactId>fest-assert</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
+
     </dependencies>
 </project>

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/model/MergedConfigurationHolder.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/model/MergedConfigurationHolder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.orchestrator.model;
+
+
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+
+public class MergedConfigurationHolder {
+
+    private final Set<Long> cancelledExecutions;
+    private final Set<String> pausedExecutionBranchIdPairs;
+    private final Map<String, Set<String>> workerGroupsMap;
+
+    public MergedConfigurationHolder() {
+        this.cancelledExecutions = emptySet();
+        this.pausedExecutionBranchIdPairs = emptySet();
+        this.workerGroupsMap = emptyMap();
+    }
+
+    public MergedConfigurationHolder(Set<Long> cancelledExecutions, Set<String> pausedExecutions,
+            Map<String, Set<String>> workerGroupsMap) {
+        this.cancelledExecutions = cancelledExecutions;
+        this.pausedExecutionBranchIdPairs = pausedExecutions;
+        this.workerGroupsMap = workerGroupsMap;
+    }
+
+    public Set<Long> getCancelledExecutions() {
+        return cancelledExecutions;
+    }
+
+    public Set<String> getPausedExecutionBranchIdPairs() {
+        return pausedExecutionBranchIdPairs;
+    }
+
+    public Set<String> getWorkerGroupsForWorker(String workerId) {
+        Set<String> groups = workerGroupsMap.get(workerId);
+        return (groups != null) ? groups : emptySet();
+    }
+
+}

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/MergedConfigurationServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/MergedConfigurationServiceImpl.java
@@ -78,7 +78,7 @@ public class MergedConfigurationServiceImpl implements MergedConfigurationServic
     }
 
     /**
-     * Read data from memory that is periodically refreshed from database
+     * Read data from memory, this data is periodically refreshed from database by scheduledExecutor executor.
      */
     @Override
     public MergedConfigurationDataContainer fetchMergedConfiguration(String workerUuid) {
@@ -138,17 +138,17 @@ public class MergedConfigurationServiceImpl implements MergedConfigurationServic
                 Set<Long> cancelledExecutions;
                 try {
                     cancelledExecutions = new HashSet<>(cancelExecutionService.readCanceledExecutionsIds());
-                } catch (Exception ex) {
+                } catch (Exception readCancelledExc) {
                     cancelledExecutions = emptySet();
-                    log.error("Failed to fetch cancelled information: ", ex);
+                    log.error("Failed to read cancelled executions information: ", readCancelledExc);
                 }
 
                 Set<String> pausedExecutionBranchIds;
                 try {
                     pausedExecutionBranchIds = pauseResumeService.readAllPausedExecutionBranchIdsNoCache();
-                } catch (Exception ex) {
+                } catch (Exception readPausedExecBranchPairsExc) {
                     pausedExecutionBranchIds = emptySet();
-                    log.error("Failed to read paused flows information: ", ex);
+                    log.error("Failed to read paused executions information: ", readPausedExecBranchPairsExc);
                 }
 
                 Map<String, Set<String>> workerGroupsMap;
@@ -156,7 +156,7 @@ public class MergedConfigurationServiceImpl implements MergedConfigurationServic
                     workerGroupsMap = workerNodeService.readWorkerGroupsMap();
                 } catch (Exception readWorkerGroupsExc) {
                     workerGroupsMap = emptyMap();
-                    log.error("Failed to fetch worker group information: ", readWorkerGroupsExc);
+                    log.error("Failed to read current worker group information: ", readWorkerGroupsExc);
                 }
 
                 // Construct the object that is queries

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/MergedConfigurationServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/MergedConfigurationServiceImpl.java
@@ -43,7 +43,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class MergedConfigurationServiceImpl implements MergedConfigurationService {
 
     private static final Logger log = Logger.getLogger(MergedConfigurationServiceImpl.class);
-    private static final long MERGED_CONFIGURATION_PERIODIC_REFRESH_MILLIS = getLong("worker.mergedConfiguration.refreshDelayMillis", 2300L);
+    private static final long MERGED_CONFIGURATION_PERIODIC_REFRESH_MILLIS = getLong("worker.mergedConfiguration.refreshDelayMillis", 2000L);
     private static final long MERGED_CONFIGURATION_INITIAL_DELAY_MILLIS = getLong("worker.mergedConfiguration.initialDelayMillis", 1000L);
 
     @Autowired

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/MergedConfigurationServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/MergedConfigurationServiceImpl.java
@@ -159,7 +159,7 @@ public class MergedConfigurationServiceImpl implements MergedConfigurationServic
                     log.error("Failed to read current worker group information: ", readWorkerGroupsExc);
                 }
 
-                // Construct the object that is queries
+                // Construct the object that is queried
                 mergedConfigHolderValue = new MergedConfigurationHolder(cancelledExecutions, pausedExecutionBranchIds, workerGroupsMap);
             } catch (Exception exception) {
                 log.error("Exception during refresh worker merged configuration information: ", exception);

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/MergedConfigurationServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/MergedConfigurationServiceImpl.java
@@ -88,6 +88,10 @@ public class MergedConfigurationServiceImpl implements MergedConfigurationServic
                 holder.getWorkerGroupsForWorker(workerUuid));
     }
 
+    AtomicReference<MergedConfigurationHolder> getMergedConfigHolderReference() {
+        return mergedConfigHolderReference;
+    }
+
     @PreDestroy
     public void destroy() {
         try {

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/MergedConfigurationServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/MergedConfigurationServiceImpl.java
@@ -43,8 +43,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class MergedConfigurationServiceImpl implements MergedConfigurationService {
 
     private static final Logger log = Logger.getLogger(MergedConfigurationServiceImpl.class);
-    private static final long MERGED_CONFIGURATION_PERIODIC_REFRESH_MILLIS = getLong("worker.mergedConfiguration.refreshDelayMillis", 2000L);
-    private static final long MERGED_CONFIGURATION_INITIAL_DELAY_MILLIS = getLong("worker.mergedConfiguration.initialDelayMillis", 1000L);
+    private static final long MERGED_CONFIGURATION_PERIODIC_REFRESH_MILLIS = getLong("worker.mergedConfiguration.refreshDelayMillis", 1_800L);
+    private static final long MERGED_CONFIGURATION_INITIAL_DELAY_MILLIS = getLong("worker.mergedConfiguration.initialDelayMillis", 1_000L);
 
     @Autowired
     private CancelExecutionService cancelExecutionService;

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/MergedConfigurationServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/MergedConfigurationServiceImpl.java
@@ -16,17 +16,35 @@
 
 package io.cloudslang.orchestrator.services;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.cloudslang.engine.node.services.WorkerNodeService;
 import io.cloudslang.orchestrator.entities.MergedConfigurationDataContainer;
+import io.cloudslang.orchestrator.model.MergedConfigurationHolder;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor.DiscardPolicy;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.lang.Long.getLong;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 
 public class MergedConfigurationServiceImpl implements MergedConfigurationService {
 
     private static final Logger log = Logger.getLogger(MergedConfigurationServiceImpl.class);
+    private static final long MERGED_CONFIGURATION_PERIODIC_REFRESH_MILLIS = getLong("worker.mergedConfiguration.refreshDelayMillis", 2300L);
+    private static final long MERGED_CONFIGURATION_INITIAL_DELAY_MILLIS = getLong("worker.mergedConfiguration.initialDelayMillis", 1000L);
 
     @Autowired
     private CancelExecutionService cancelExecutionService;
@@ -37,28 +55,118 @@ public class MergedConfigurationServiceImpl implements MergedConfigurationServic
     @Autowired
     private WorkerNodeService workerNodeService;
 
+    // Intentionally not a Spring bean as this an internal executor dedicated to the MergedConfigurationService only
+    private final ScheduledThreadPoolExecutor scheduledExecutor;
+
+    // Used to store the latest state of the MergedConfigurationHolder object,
+    // periodically reloaded every worker.mergedConfiguration.refreshIntervalInMillis millis
+    private final AtomicReference<MergedConfigurationHolder> mergedConfigHolderReference;
+
+    public MergedConfigurationServiceImpl() {
+        this.scheduledExecutor = getScheduledExecutor();
+        // Initially value points to an empty state
+        this.mergedConfigHolderReference = new AtomicReference<>(new MergedConfigurationHolder());
+    }
+
+    @PostConstruct
+    protected void schedulePeriodicRefreshOfMergedConfiguration() {
+        Runnable refreshMergedConfigRunnable = new RefreshMergedConfigurationRunnable(cancelExecutionService,
+                pauseResumeService, workerNodeService, mergedConfigHolderReference);
+        final long initialDelay = MERGED_CONFIGURATION_INITIAL_DELAY_MILLIS;
+        final long periodicDelay = MERGED_CONFIGURATION_PERIODIC_REFRESH_MILLIS;
+        scheduledExecutor.scheduleWithFixedDelay(refreshMergedConfigRunnable, initialDelay, periodicDelay, MILLISECONDS);
+    }
+
+    /**
+     * Read data from memory that is periodically refreshed from database
+     */
     @Override
     public MergedConfigurationDataContainer fetchMergedConfiguration(String workerUuid) {
-        MergedConfigurationDataContainer mergedConfigurationDataContainer = new MergedConfigurationDataContainer();
+        final MergedConfigurationHolder holder = mergedConfigHolderReference.get();
+        return new MergedConfigurationDataContainer(holder.getCancelledExecutions(),
+                holder.getPausedExecutionBranchIdPairs(),
+                holder.getWorkerGroupsForWorker(workerUuid));
+    }
+
+    @PreDestroy
+    public void destroy() {
         try {
-            mergedConfigurationDataContainer.setCancelledExecutions(new HashSet<>(cancelExecutionService.readCanceledExecutionsIds()));
-        } catch (Exception ex) {
-            log.error("Failed to fetch cancelled information: ", ex);
+            scheduledExecutor.shutdown();
+            scheduledExecutor.shutdownNow();
+        } catch (Exception failedShutdownEx) {
+            log.error("Could not shutdown merged configuration container executor: ", failedShutdownEx);
+        }
+    }
+
+    private ScheduledThreadPoolExecutor getScheduledExecutor() {
+        final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat("merged-config-refresher-%d")
+                .setDaemon(true)
+                .build();
+
+        // Intentionally 1 thread
+        ScheduledThreadPoolExecutor scheduledExecutor = new ScheduledThreadPoolExecutor(1, threadFactory);
+        scheduledExecutor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+        scheduledExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+        scheduledExecutor.setRemoveOnCancelPolicy(true);
+        scheduledExecutor.setRejectedExecutionHandler(new DiscardPolicy());
+        return scheduledExecutor;
+    }
+
+    private static class RefreshMergedConfigurationRunnable implements Runnable {
+
+        private final CancelExecutionService cancelExecutionService;
+        private final PauseResumeService pauseResumeService;
+        private final WorkerNodeService workerNodeService;
+        private final AtomicReference<MergedConfigurationHolder> ref;
+
+        public RefreshMergedConfigurationRunnable(CancelExecutionService cancelExecutionService,
+                PauseResumeService pauseResumeService,
+                WorkerNodeService workerNodeService,
+                AtomicReference<MergedConfigurationHolder> ref) {
+
+            this.cancelExecutionService = cancelExecutionService;
+            this.pauseResumeService = pauseResumeService;
+            this.workerNodeService = workerNodeService;
+            this.ref = ref;
         }
 
-        try {
-            mergedConfigurationDataContainer.setPausedExecutions(pauseResumeService.readAllPausedExecutionBranchIds());
-        } catch (Exception ex) {
-            log.error("Failed to read paused flows information: ", ex);
-        }
+        @Override
+        public void run() {
+            MergedConfigurationHolder mergedConfigHolderValue = null;
+            try {
+                Set<Long> cancelledExecutions;
+                try {
+                    cancelledExecutions = new HashSet<>(cancelExecutionService.readCanceledExecutionsIds());
+                } catch (Exception ex) {
+                    cancelledExecutions = emptySet();
+                    log.error("Failed to fetch cancelled information: ", ex);
+                }
 
-        try {
-            mergedConfigurationDataContainer.setWorkerGroups(new HashSet<>(workerNodeService.readWorkerGroups(workerUuid)));
-        } catch (Exception ex) {
-            log.error("Failed to fetch worker group information: ", ex);
-        }
+                Set<String> pausedExecutionBranchIds;
+                try {
+                    pausedExecutionBranchIds = pauseResumeService.readAllPausedExecutionBranchIdsNoCache();
+                } catch (Exception ex) {
+                    pausedExecutionBranchIds = emptySet();
+                    log.error("Failed to read paused flows information: ", ex);
+                }
 
-        return mergedConfigurationDataContainer;
+                Map<String, Set<String>> workerGroupsMap;
+                try {
+                    workerGroupsMap = workerNodeService.readWorkerGroupsMap();
+                } catch (Exception readWorkerGroupsExc) {
+                    workerGroupsMap = emptyMap();
+                    log.error("Failed to fetch worker group information: ", readWorkerGroupsExc);
+                }
+
+                // Construct the object that is queries
+                mergedConfigHolderValue = new MergedConfigurationHolder(cancelledExecutions, pausedExecutionBranchIds, workerGroupsMap);
+            } catch (Exception exception) {
+                log.error("Exception during refresh worker merged configuration information: ", exception);
+            } finally {
+                ref.set((mergedConfigHolderValue != null) ? mergedConfigHolderValue : new MergedConfigurationHolder());
+            }
+        }
     }
 }
 

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/StubPauseResumeServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/StubPauseResumeServiceImpl.java
@@ -70,6 +70,11 @@ public class StubPauseResumeServiceImpl implements PauseResumeService {
     }
 
     @Override
+    public Set<String> readAllPausedExecutionBranchIdsNoCache() {
+        return null;
+    }
+
+    @Override
     public ExecutionSummary readPausedExecution(Long executionId, String branchId) {
         return null;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,14 @@
                 <version>1.4</version>
                 <scope>test</scope>
             </dependency>
-            
+
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>4.0.3</version>
+                <scope>test</scope>
+            </dependency>
+
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>


### PR DESCRIPTION
Optimized merged configuration by using a single orchestrator job instead of per worker job to update the merged configuration.
Refresh period can be controlled using `"worker.mergedConfiguration.refreshDelayMillis"` system property. Its default value is `1_800 miliseconds`.
Signed-off-by: Lucian Musca lucian-cristian.musca@microfocus.com