### PR TITLE
python 3 timeout performance fix

### DIFF
--- a/runtime-management/runtime-management-api/src/main/java/io/cloudslang/runtime/api/python/ExternalPythonProcessRunService.java
+++ b/runtime-management/runtime-management-api/src/main/java/io/cloudslang/runtime/api/python/ExternalPythonProcessRunService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.cloudslang.runtime.api.python;
 
 

--- a/runtime-management/runtime-management-api/src/main/java/io/cloudslang/runtime/api/python/ExternalPythonProcessRunService.java
+++ b/runtime-management/runtime-management-api/src/main/java/io/cloudslang/runtime/api/python/ExternalPythonProcessRunService.java
@@ -1,0 +1,14 @@
+package io.cloudslang.runtime.api.python;
+
+
+import java.io.Serializable;
+import java.util.Map;
+
+public interface ExternalPythonProcessRunService {
+
+    PythonExecutionResult exec(String script, Map<String, Serializable> inputs);
+    PythonEvaluationResult eval(String expression, String prepareEnvironmentScript, Map<String, Serializable> context);
+    PythonEvaluationResult test(String expression, String prepareEnvironmentScript, Map<String, Serializable> context,
+            long timeout);
+
+}

--- a/runtime-management/runtime-management-api/src/main/java/io/cloudslang/runtime/api/python/ExternalPythonProcessRunService.java
+++ b/runtime-management/runtime-management-api/src/main/java/io/cloudslang/runtime/api/python/ExternalPythonProcessRunService.java
@@ -25,5 +25,6 @@ public interface ExternalPythonProcessRunService {
     PythonEvaluationResult eval(String expression, String prepareEnvironmentScript, Map<String, Serializable> context);
     PythonEvaluationResult test(String expression, String prepareEnvironmentScript, Map<String, Serializable> context,
             long timeout);
+    String getStrategyName();
 
 }

--- a/runtime-management/runtime-management-impl/pom.xml
+++ b/runtime-management/runtime-management-impl/pom.xml
@@ -16,7 +16,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,29 +30,35 @@
     <artifactId>runtime-management-impl</artifactId>
 
     <dependencies>
+
         <dependency>
             <groupId>io.cloudslang</groupId>
             <artifactId>runtime-management-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>io.cloudslang</groupId>
             <artifactId>dependency-management-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>io.cloudslang</groupId>
             <artifactId>dependency-management-impl</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>
+
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
+
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
@@ -60,16 +67,19 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-         <dependency>
+
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.python</groupId>
             <artifactId>jython-standalone</artifactId>
             <version>2.7.2</version>
             <scope>compile</scope>
         </dependency>
+
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
@@ -81,20 +91,28 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutionEngine.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutionEngine.java
@@ -48,7 +48,7 @@ public class ExternalPythonExecutionEngine implements PythonExecutionEngine {
             pythonRunServiceSupplier = () -> new ExternalPythonExecutorCompletableFutureTimeout();
 
         } else { // Use default
-            pythonRunServiceSupplier = () -> new ExternalPythonExecutorCompletableFutureTimeout();
+            pythonRunServiceSupplier = () -> new ExternalPythonExecutorScheduledExecutorTimeout();
         }
         logger.info("python timeout strategy: " + pythonRunServiceSupplier.get().getStrategyName());
     }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutionEngine.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutionEngine.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 public class ExternalPythonExecutionEngine implements PythonExecutionEngine {
+
     private static final Logger logger = LogManager.getLogger(ExternalPythonExecutionEngine.class);
     private static final Supplier<ExternalPythonProcessRunService> pythonRunServiceSupplier;
 

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutionEngine.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutionEngine.java
@@ -32,15 +32,21 @@ public class ExternalPythonExecutionEngine implements PythonExecutionEngine {
 
     private static final Logger logger = LogManager.getLogger(ExternalPythonExecutionEngine.class);
     private static final Supplier<ExternalPythonProcessRunService> pythonRunServiceSupplier;
+    public static final String WAIT_FOR_STRATEGY = "wait-for";
+    public static final String SCHEDULED_EXECUTOR_STRATEGY = "scheduled-executor";
+    public static final String COMPLETABLE_EXECUTOR_STRATEGY = "completable-future";
 
     static {
-        String timeoutStrategy = System.getProperty("python.timeoutStrategy", "completable-future");
-        if (StringUtils.equalsIgnoreCase(timeoutStrategy, "scheduled-executor")) {
+        String timeoutStrategy = System.getProperty("python.timeoutStrategy", COMPLETABLE_EXECUTOR_STRATEGY);
+        if (StringUtils.equalsIgnoreCase(timeoutStrategy, SCHEDULED_EXECUTOR_STRATEGY)) {
             pythonRunServiceSupplier = () -> new ExternalPythonExecutorScheduledExecutorTimeout();
-        } else if (StringUtils.equalsIgnoreCase(timeoutStrategy, "waitfor")) {
+
+        } else if (StringUtils.equalsIgnoreCase(timeoutStrategy, WAIT_FOR_STRATEGY)) {
             pythonRunServiceSupplier = () -> new ExternalPythonExecutorWaitForTimeout();
-        } else if (StringUtils.equalsIgnoreCase(timeoutStrategy, "completable-future")) {
+
+        } else if (StringUtils.equalsIgnoreCase(timeoutStrategy, COMPLETABLE_EXECUTOR_STRATEGY)) {
             pythonRunServiceSupplier = () -> new ExternalPythonExecutorCompletableFutureTimeout();
+
         } else { // Use default
             pythonRunServiceSupplier = () -> new ExternalPythonExecutorCompletableFutureTimeout();
         }
@@ -63,6 +69,5 @@ public class ExternalPythonExecutionEngine implements PythonExecutionEngine {
     public PythonEvaluationResult test(String prepareEnvironmentScript, String script, Map<String, Serializable> vars, long timeout) {
         ExternalPythonProcessRunService pythonExecutor = pythonRunServiceSupplier.get();
         return pythonExecutor.test(script, prepareEnvironmentScript, vars, timeout);
-
     }
 }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutionEngine.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutionEngine.java
@@ -20,6 +20,8 @@ import io.cloudslang.runtime.api.python.PythonEvaluationResult;
 import io.cloudslang.runtime.api.python.PythonExecutionResult;
 import io.cloudslang.runtime.impl.python.PythonExecutionEngine;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.Serializable;
 import java.util.Map;
@@ -27,7 +29,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 public class ExternalPythonExecutionEngine implements PythonExecutionEngine {
-
+    private static final Logger logger = LogManager.getLogger(ExternalPythonExecutionEngine.class);
     private static final Supplier<ExternalPythonProcessRunService> pythonRunServiceSupplier;
 
     static {
@@ -41,6 +43,7 @@ public class ExternalPythonExecutionEngine implements PythonExecutionEngine {
         } else { // Use default
             pythonRunServiceSupplier = () -> new ExternalPythonExecutorCompletableFutureTimeout();
         }
+        logger.info("python timeout strategy: " + pythonRunServiceSupplier.get().getStrategyName());
     }
 
     @Override

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutionEngine.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutionEngine.java
@@ -15,31 +15,49 @@
  */
 package io.cloudslang.runtime.impl.python.external;
 
+import io.cloudslang.runtime.api.python.ExternalPythonProcessRunService;
 import io.cloudslang.runtime.api.python.PythonEvaluationResult;
 import io.cloudslang.runtime.api.python.PythonExecutionResult;
 import io.cloudslang.runtime.impl.python.PythonExecutionEngine;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public class ExternalPythonExecutionEngine implements PythonExecutionEngine {
 
+    private static final Supplier<ExternalPythonProcessRunService> pythonRunServiceSupplier;
+
+    static {
+        String timeoutStrategy = System.getProperty("python.timeoutStrategy", "completable-future");
+        if (StringUtils.equalsIgnoreCase(timeoutStrategy, "scheduled-executor")) {
+            pythonRunServiceSupplier = () -> new ExternalPythonExecutorScheduledExecutorTimeout();
+        } else if (StringUtils.equalsIgnoreCase(timeoutStrategy, "waitfor")) {
+            pythonRunServiceSupplier = () -> new ExternalPythonExecutorWaitForTimeout();
+        } else if (StringUtils.equalsIgnoreCase(timeoutStrategy, "completable-future")) {
+            pythonRunServiceSupplier = () -> new ExternalPythonExecutorCompletableFutureTimeout();
+        } else { // Use default
+            pythonRunServiceSupplier = () -> new ExternalPythonExecutorCompletableFutureTimeout();
+        }
+    }
+
     @Override
     public PythonExecutionResult exec(Set<String> dependencies, String script, Map<String, Serializable> vars) {
-        ExternalPythonExecutor pythonExecutor = new ExternalPythonExecutor();
+        ExternalPythonProcessRunService pythonExecutor = pythonRunServiceSupplier.get();
         return pythonExecutor.exec(script, vars);
     }
 
     @Override
     public PythonEvaluationResult eval(String prepareEnvironmentScript, String script, Map<String, Serializable> vars) {
-        ExternalPythonExecutor pythonExecutor = new ExternalPythonExecutor();
+        ExternalPythonProcessRunService pythonExecutor = pythonRunServiceSupplier.get();
         return pythonExecutor.eval(script, prepareEnvironmentScript, vars);
     }
 
     @Override
     public PythonEvaluationResult test(String prepareEnvironmentScript, String script, Map<String, Serializable> vars, long timeout) {
-        ExternalPythonExecutor pythonExecutor = new ExternalPythonExecutor();
+        ExternalPythonProcessRunService pythonExecutor = pythonRunServiceSupplier.get();
         return pythonExecutor.test(script, prepareEnvironmentScript, vars, timeout);
 
     }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutionEngine.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutionEngine.java
@@ -37,7 +37,7 @@ public class ExternalPythonExecutionEngine implements PythonExecutionEngine {
     public static final String COMPLETABLE_EXECUTOR_STRATEGY = "completable-future";
 
     static {
-        String timeoutStrategy = System.getProperty("python.timeoutStrategy", COMPLETABLE_EXECUTOR_STRATEGY);
+        String timeoutStrategy = System.getProperty("python.timeoutStrategy", SCHEDULED_EXECUTOR_STRATEGY);
         if (StringUtils.equalsIgnoreCase(timeoutStrategy, SCHEDULED_EXECUTOR_STRATEGY)) {
             pythonRunServiceSupplier = () -> new ExternalPythonExecutorScheduledExecutorTimeout();
 

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorCompletableFutureTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorCompletableFutureTimeout.java
@@ -65,6 +65,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeoutException;
 
+import static io.cloudslang.runtime.impl.python.external.ExternalPythonExecutionEngine.COMPLETABLE_EXECUTOR_STRATEGY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -347,6 +348,6 @@ public class ExternalPythonExecutorCompletableFutureTimeout implements ExternalP
 
     @Override
     public String getStrategyName() {
-        return "completable-future";
+        return COMPLETABLE_EXECUTOR_STRATEGY;
     }
 }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorCompletableFutureTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorCompletableFutureTimeout.java
@@ -345,4 +345,8 @@ public class ExternalPythonExecutorCompletableFutureTimeout implements ExternalP
         return trace.substring(pythonFileNameIndex + PYTHON_FILENAME_DELIMITERS);
     }
 
+    @Override
+    public String getStrategyName() {
+        return "completable-future";
+    }
 }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorCompletableFutureTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorCompletableFutureTimeout.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.runtime.impl.python.external;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.cloudslang.runtime.api.python.ExternalPythonProcessRunService;
+import io.cloudslang.runtime.api.python.PythonEvaluationResult;
+import io.cloudslang.runtime.api.python.PythonExecutionResult;
+import io.cloudslang.runtime.impl.python.external.model.TempEnvironment;
+import io.cloudslang.runtime.impl.python.external.model.TempEvalEnvironment;
+import io.cloudslang.runtime.impl.python.external.model.TempExecutionEnvironment;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.SystemUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeoutException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
+
+public class ExternalPythonExecutorCompletableFutureTimeout implements ExternalPythonProcessRunService {
+
+    private static final Logger logger = LogManager.getLogger(ExternalPythonExecutorCompletableFutureTimeout.class);
+    private static final String PYTHON_SCRIPT_FILENAME = "script";
+    private static final String EVAL_PY = "eval.py";
+    private static final String MAIN_PY = "main.py";
+    private static final String PYTHON_SUFFIX = ".py";
+    private static final long EXECUTION_TIMEOUT = Long.getLong("python.timeout", 30) * 60 * 1000;
+    private static final long EVALUATION_TIMEOUT = Long.getLong("python.evaluation.timeout", 3) * 60 * 1000;
+    private static final int ENGINE_EXECUTOR_THREAD_COUNT = Integer.getInteger("python.executor.threadCount", 10);
+    private static final int TEST_EXECUTOR_THREAD_COUNT = Integer.getInteger("test.executor.threadCount", 3);
+    private static final String PYTHON_FILENAME_SCRIPT_EXTENSION = ".py\"";
+    private static final int PYTHON_FILENAME_DELIMITERS = 6;
+    private static final ObjectMapper objectMapper;
+    private static final ExecutorService engineExecutorService;
+    private static final ExecutorService testExecutorService;
+
+    static {
+        JsonFactory factory = new JsonFactory();
+        factory.enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES);
+        factory.enable(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature());
+        objectMapper = new ObjectMapper(factory);
+    }
+
+    static {
+        final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat("python-engine-%d")
+                .setDaemon(true)
+                .build();
+        engineExecutorService = Executors.newFixedThreadPool(ENGINE_EXECUTOR_THREAD_COUNT, threadFactory);
+
+    }
+
+    static {
+        final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat("python-test-%d")
+                .setDaemon(true)
+                .build();
+        testExecutorService = Executors.newFixedThreadPool(TEST_EXECUTOR_THREAD_COUNT, threadFactory);
+    }
+
+    @Override
+    public PythonExecutionResult exec(String script, Map<String, Serializable> inputs) {
+        TempExecutionEnvironment tempExecutionEnvironment = null;
+        try {
+            String pythonPath = checkPythonPath();
+            tempExecutionEnvironment = generateTempResourcesForExec(script);
+            String payload = generatePayloadForExec(tempExecutionEnvironment.getUserScriptName(), inputs);
+            addFilePermissions(tempExecutionEnvironment.getParentFolder());
+
+            return runPythonExecutionProcess(pythonPath, payload, tempExecutionEnvironment);
+
+        } catch (IOException e) {
+            String message = "Failed to generate execution resources";
+            logger.error(message, e);
+            throw new RuntimeException(message);
+        } finally {
+            if ((tempExecutionEnvironment != null) && !deleteQuietly(tempExecutionEnvironment.getParentFolder())) {
+                logger.warn(String.format("Failed to cleanup python execution resources {%s}",
+                        tempExecutionEnvironment.getParentFolder()));
+            }
+        }
+    }
+
+    @Override
+    public PythonEvaluationResult eval(String expression, String prepareEnvironmentScript,
+            Map<String, Serializable> context) {
+        return getPythonEvaluationResult(expression, prepareEnvironmentScript, context, EVALUATION_TIMEOUT,
+                engineExecutorService);
+    }
+
+    @Override
+    public PythonEvaluationResult test(String expression, String prepareEnvironmentScript,
+            Map<String, Serializable> context, long timeout) {
+        return getPythonEvaluationResult(expression, prepareEnvironmentScript, context, timeout, testExecutorService);
+    }
+
+    private PythonEvaluationResult getPythonEvaluationResult(String expression, String prepareEnvironmentScript,
+            Map<String, Serializable> context, long evaluationTimeout, ExecutorService executorService) {
+        TempEvalEnvironment tempEvalEnvironment = null;
+        try {
+            String pythonPath = checkPythonPath();
+            tempEvalEnvironment = generateTempResourcesForEval();
+            String payload = generatePayloadForEval(expression, prepareEnvironmentScript, context);
+            addFilePermissions(tempEvalEnvironment.getParentFolder());
+
+            return runPythonEvalProcess(pythonPath, payload, tempEvalEnvironment, context, evaluationTimeout,
+                    executorService);
+
+        } catch (IOException e) {
+            String message = "Failed to generate execution resources";
+            logger.error(message, e);
+            throw new RuntimeException(message);
+        } finally {
+            if ((tempEvalEnvironment != null) && !deleteQuietly(tempEvalEnvironment.getParentFolder())) {
+                logger.warn(String.format("Failed to cleanup python execution resources {%s}",
+                        tempEvalEnvironment.getParentFolder()));
+            }
+        }
+    }
+
+    private void addFilePermissions(File file) throws IOException {
+        Set<PosixFilePermission> filePermissions = new HashSet<>();
+        filePermissions.add(PosixFilePermission.OWNER_READ);
+
+        File[] fileChildren = file.listFiles();
+
+        if (fileChildren != null) {
+            for (File child : fileChildren) {
+                if (SystemUtils.IS_OS_WINDOWS) {
+                    child.setReadOnly();
+                } else {
+                    Files.setPosixFilePermissions(child.toPath(), filePermissions);
+                }
+            }
+        }
+    }
+
+    private String checkPythonPath() {
+        String pythonPath = System.getProperty("python.path");
+        if (StringUtils.isEmpty(pythonPath) || !new File(pythonPath).exists()) {
+            throw new IllegalArgumentException("Missing or invalid python path");
+        }
+        return pythonPath;
+    }
+
+    private Document parseScriptExecutionResult(String scriptExecutionResult)
+            throws IOException, ParserConfigurationException, SAXException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        InputSource is = new InputSource();
+        is.setCharacterStream(new StringReader(scriptExecutionResult));
+        return db.parse(is);
+    }
+
+    private PythonExecutionResult runPythonExecutionProcess(String pythonPath, String payload,
+            TempExecutionEnvironment executionEnvironment) {
+
+        ProcessBuilder processBuilder = preparePythonProcess(executionEnvironment, pythonPath);
+
+        try {
+            String returnResult = getResult(payload, processBuilder, EXECUTION_TIMEOUT, engineExecutorService);
+            returnResult = parseScriptExecutionResult(returnResult).getElementsByTagName("result").item(0)
+                    .getTextContent();
+            ScriptResults scriptResults = objectMapper.readValue(returnResult, ScriptResults.class);
+            String exception = formatException(scriptResults.getException(), scriptResults.getTraceback());
+
+            if (!StringUtils.isEmpty(exception)) {
+                logger.error(String.format("Failed to execute script {%s}", exception));
+                throw new ExternalPythonScriptException(String.format("Failed to execute user script: %s", exception));
+            }
+
+            //noinspection unchecked
+            return new PythonExecutionResult(scriptResults.getReturnResult());
+        } catch (IOException | InterruptedException | SAXException | ParserConfigurationException | ExecutionException e) {
+            logger.error("Failed to run script. ", e.getCause() != null ? e.getCause() : e);
+            throw new RuntimeException("Failed to run script.");
+        }
+    }
+
+    private PythonEvaluationResult runPythonEvalProcess(String pythonPath, String payload,
+            TempEvalEnvironment executionEnvironment,
+            Map<String, Serializable> context, long timeout, ExecutorService executorService) {
+
+        ProcessBuilder processBuilder = preparePythonProcess(executionEnvironment, pythonPath);
+
+        try {
+            String returnResult = getResult(payload, processBuilder, timeout, executorService);
+
+            EvaluationResults scriptResults = objectMapper.readValue(returnResult, EvaluationResults.class);
+            String exception = scriptResults.getException();
+            if (!StringUtils.isEmpty(exception)) {
+                logger.error(String.format("Failed to execute script {%s}", exception));
+                throw new ExternalPythonEvalException(exception);
+            }
+            context.put("accessed_resources_set", (Serializable) scriptResults.getAccessedResources());
+            //noinspection unchecked
+            return new PythonEvaluationResult(processReturnResult(scriptResults), context);
+        } catch (IOException | InterruptedException | ExecutionException e) {
+            logger.error("Failed to run script. ", e.getCause() != null ? e.getCause() : e);
+            throw new RuntimeException("Failed to run script.");
+        }
+    }
+
+
+    private Serializable processReturnResult(EvaluationResults results) throws JsonProcessingException {
+        EvaluationResults.ReturnType returnType = results.getReturnType();
+        if (returnType == null) {
+            throw new RuntimeException("Missing return type for return result.");
+        }
+        switch (returnType) {
+            case BOOLEAN:
+                return Boolean.valueOf(results.getReturnResult());
+            case INTEGER:
+                return Integer.valueOf(results.getReturnResult());
+            case LIST:
+                return objectMapper.readValue(results.getReturnResult(), new TypeReference<ArrayList<Serializable>>() {
+                });
+            default:
+                return results.getReturnResult();
+        }
+    }
+
+    private String getResult(final String payload, final ProcessBuilder processBuilder, final long timeoutPeriodMillis,
+            ExecutorService executorService) throws InterruptedException, ExecutionException {
+        ExternalPythonEvaluationSupplier supplier = new ExternalPythonEvaluationSupplier(processBuilder, payload);
+        try {
+            return supplyAsync(supplier, executorService).get(timeoutPeriodMillis, MILLISECONDS);
+        } catch (TimeoutException timeoutException) {
+            supplier.destroyProcess();
+            throw new RuntimeException("Timeout " + timeoutPeriodMillis + " has been reached: ", timeoutException);
+        }
+    }
+
+    private ProcessBuilder preparePythonProcess(TempEnvironment executionEnvironment, String pythonPath) {
+        ProcessBuilder processBuilder = new ProcessBuilder(Arrays.asList(Paths.get(pythonPath, "python").toString(),
+                Paths.get(executionEnvironment.getParentFolder().toString(), executionEnvironment.getMainScriptName())
+                        .toString()));
+        processBuilder.environment().clear();
+        processBuilder.directory(executionEnvironment.getParentFolder());
+        return processBuilder;
+    }
+
+    private TempExecutionEnvironment generateTempResourcesForExec(String script) throws IOException {
+        Path execTempDirectory = Files.createTempDirectory("python_execution");
+        File tempUserScript = File.createTempFile(PYTHON_SCRIPT_FILENAME, PYTHON_SUFFIX, execTempDirectory.toFile());
+        FileUtils.writeStringToFile(tempUserScript, script, UTF_8);
+
+        File mainScriptFile = new File(execTempDirectory.toString(), MAIN_PY);
+        FileUtils.writeByteArrayToFile(mainScriptFile, ResourceScriptResolver.loadExecScriptAsBytes());
+
+        String tempUserScriptName = FilenameUtils.getName(tempUserScript.toString());
+        return new TempExecutionEnvironment(tempUserScriptName, MAIN_PY, execTempDirectory.toFile());
+    }
+
+    private TempEvalEnvironment generateTempResourcesForEval() throws IOException {
+        Path execTempDirectory = Files.createTempDirectory("python_expression");
+        File evalScriptFile = new File(execTempDirectory.toString(), EVAL_PY);
+        FileUtils.writeByteArrayToFile(evalScriptFile, ResourceScriptResolver.loadEvalScriptAsBytes());
+
+        return new TempEvalEnvironment(EVAL_PY, execTempDirectory.toFile());
+    }
+
+    private String generatePayloadForEval(String expression, String prepareEnvironmentScript,
+            Map<String, Serializable> context) throws JsonProcessingException {
+        HashMap<String, Serializable> payload = new HashMap<>(4);
+        payload.put("expression", expression);
+        payload.put("envSetup", prepareEnvironmentScript);
+        payload.put("context", (Serializable) context);
+        return objectMapper.writeValueAsString(payload);
+    }
+
+    private String generatePayloadForExec(String userScript, Map<String, Serializable> inputs) throws
+            JsonProcessingException {
+        HashMap<String, String> parsedInputs = new HashMap<>();
+        for (Entry<String, Serializable> entry : inputs.entrySet()) {
+            parsedInputs.put(entry.getKey(), entry.getValue().toString());
+        }
+
+        Map<String, Serializable> payload = new HashMap<>(3);
+        payload.put("script_name", FilenameUtils.removeExtension(userScript));
+        payload.put("inputs", parsedInputs);
+        return objectMapper.writeValueAsString(payload);
+    }
+
+    private String formatException(String exception, List<String> traceback) {
+        return CollectionUtils.isEmpty(traceback) ? exception
+                : removeFileName(traceback.get(traceback.size() - 1)) + ", " + exception;
+    }
+
+    private String removeFileName(String trace) {
+        int pythonFileNameIndex = trace.indexOf(PYTHON_FILENAME_SCRIPT_EXTENSION);
+        return trace.substring(pythonFileNameIndex + PYTHON_FILENAME_DELIMITERS);
+    }
+
+}

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorCompletableFutureTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorCompletableFutureTimeout.java
@@ -281,7 +281,7 @@ public class ExternalPythonExecutorCompletableFutureTimeout implements ExternalP
             return supplyAsync(supplier, executorService).get(timeoutPeriodMillis, MILLISECONDS);
         } catch (TimeoutException timeoutException) {
             supplier.destroyProcess();
-            throw new RuntimeException("Timeout " + timeoutPeriodMillis + " has been reached: ", timeoutException);
+            throw new RuntimeException("Python timeout of " + timeoutPeriodMillis + " millis has been reached: ", timeoutException);
         }
     }
 

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorCompletableFutureTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorCompletableFutureTimeout.java
@@ -281,7 +281,7 @@ public class ExternalPythonExecutorCompletableFutureTimeout implements ExternalP
             return supplyAsync(supplier, executorService).get(timeoutPeriodMillis, MILLISECONDS);
         } catch (TimeoutException timeoutException) {
             supplier.destroyProcess();
-            throw new RuntimeException("Python timeout of " + timeoutPeriodMillis + " millis has been reached: ", timeoutException);
+            throw new RuntimeException("Python timeout of " + timeoutPeriodMillis + " millis has been reached");
         }
     }
 

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
@@ -377,8 +377,9 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
         } catch (IOException ioException) {
             if (TRUE.equals(timeoutMap.get(uniqueKey))) {
                 throw new RuntimeException("Timeout " + timeoutPeriodMillis + " has been reached");
+            } else {
+                throw new RuntimeException("Script execution failed: ", ioException);
             }
-            throw new RuntimeException("Script execution failed: ", ioException);
         } finally {
             // Remove from timeoutScheduledExecutor queue, because of setRemoveOnCancelPolicy(true)
             if (scheduledFuture != null) {

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
@@ -373,6 +373,7 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
         } catch (InterruptedException interruptedException) {
             if (timedOut.isTrue()) {
                 destroyProcess(process);
+                // Clear the interrupted status back
                 //noinspection ResultOfMethodCallIgnored
                 Thread.interrupted();
                 throw new RuntimeException("Python timeout of " + timeoutPeriodMillis + " millis has been reached");

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
@@ -308,7 +308,7 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
 
             if (threadTest.isAlive()) { // Test python script timed out
                 testRunnable.destroyProcess();
-                throw new RuntimeException("Timeout " + timeout + " has been reached");
+                throw new RuntimeException("Python timeout of " + timeout + " millis has been reached");
             }
 
             // Test python script encountered an exception during its execution

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
@@ -380,7 +380,6 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
             return returnResult.toString();
         } catch (Exception exception) {
             if (TRUE.equals(timeoutMap.get(uniqueKey))) { // intentional to not call get twice
-                destroyProcess(process);
                 throw new RuntimeException("Python timeout of " + timeoutPeriodMillis + " millis has been reached");
             } else {
                 throw new RuntimeException("Script execution failed: ", exception);

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
@@ -93,7 +93,6 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
     private static final AtomicLong timeoutCounter = new AtomicLong();
     private static final ThreadFactory testThreadFactory;
 
-
     static {
         JsonFactory factory = new JsonFactory();
         factory.enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES);
@@ -154,7 +153,7 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
     @Override
     public PythonEvaluationResult eval(String expression, String prepareEnvironmentScript,
             Map<String, Serializable> context) {
-        return getPythonEvaluationResult(expression, prepareEnvironmentScript, context, EVALUATION_TIMEOUT);
+        return getPythonEvaluationResult(expression, prepareEnvironmentScript, context);
     }
 
     @Override
@@ -187,7 +186,7 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
     }
 
     private PythonEvaluationResult getPythonEvaluationResult(String expression, String prepareEnvironmentScript,
-            Map<String, Serializable> context, long evaluationTimeout) {
+            Map<String, Serializable> context) {
         TempEvalEnvironment tempEvalEnvironment = null;
         try {
             String pythonPath = checkPythonPath();
@@ -195,7 +194,8 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
             String payload = generatePayloadForEval(expression, prepareEnvironmentScript, context);
             addFilePermissions(tempEvalEnvironment.getParentFolder());
 
-            return runPythonEvalProcess(pythonPath, payload, tempEvalEnvironment, context, evaluationTimeout);
+            return runPythonEvalProcess(pythonPath, payload, tempEvalEnvironment, context,
+                    ExternalPythonExecutorScheduledExecutorTimeout.EVALUATION_TIMEOUT);
 
         } catch (IOException e) {
             String message = "Failed to generate execution resources";

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
@@ -373,6 +373,8 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
         } catch (InterruptedException interruptedException) {
             if (timedOut.isTrue()) {
                 destroyProcess(process);
+                //noinspection ResultOfMethodCallIgnored
+                Thread.interrupted();
                 throw new RuntimeException("Python timeout of " + timeoutPeriodMillis + " millis has been reached");
             } else {
                 throw new RuntimeException(interruptedException);

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
@@ -71,6 +71,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static io.cloudslang.runtime.impl.python.external.ExternalPythonExecutionEngine.SCHEDULED_EXECUTOR_STRATEGY;
 import static java.lang.Boolean.TRUE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -452,6 +453,6 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
 
     @Override
     public String getStrategyName() {
-        return "scheduled-executor";
+        return SCHEDULED_EXECUTOR_STRATEGY;
     }
 }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
@@ -376,7 +376,7 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
                 returnResult.append(line);
             }
             return returnResult.toString();
-        } catch (IOException exception) {
+        } catch (Exception exception) {
             if (TRUE.equals(timeoutMap.get(uniqueKey))) {
                 if (process != null) {
                     try {

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
@@ -353,17 +353,17 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
         }
     }
 
-    private String getResult(final String payload,
-            final ProcessBuilder processBuilder,
-            final long timeoutPeriodMillis) {
+    private String getResult(final String payload, final ProcessBuilder processBuilder, final long timeoutPeriodMillis) {
+
         final long uniqueKey = timeoutCounter.incrementAndGet();
         ScheduledFuture<?> scheduledFuture = null;
+
         try {
             Process process = processBuilder.start();
             timeoutMap.put(uniqueKey, process);
-            ExternalPythonTimeoutRunnable runnable = new ExternalPythonTimeoutRunnable(uniqueKey, timeoutMap);
-            scheduledFuture = timeoutScheduledExecutor
-                    .schedule(runnable, timeoutPeriodMillis, MILLISECONDS);
+            final ExternalPythonTimeoutRunnable runnable = new ExternalPythonTimeoutRunnable(uniqueKey, timeoutMap);
+            scheduledFuture = timeoutScheduledExecutor.schedule(runnable, timeoutPeriodMillis, MILLISECONDS);
+
             PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(process.getOutputStream(), UTF_8));
             printWriter.println(payload);
             printWriter.flush();
@@ -380,6 +380,7 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
             }
             throw new RuntimeException("Script execution failed: ", ioException);
         } finally {
+            // Remove from timeoutScheduledExecutor queue, because of setRemoveOnCancelPolicy(true)
             if (scheduledFuture != null) {
                 scheduledFuture.cancel(false);
             }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
@@ -369,6 +369,7 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
             PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(process.getOutputStream(), UTF_8));
             printWriter.println(payload);
             printWriter.flush();
+            process.waitFor();
             BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
             String line;
             StringBuilder returnResult = new StringBuilder();

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorScheduledExecutorTimeout.java
@@ -450,4 +450,8 @@ public class ExternalPythonExecutorScheduledExecutorTimeout implements ExternalP
         return trace.substring(pythonFileNameIndex + PYTHON_FILENAME_DELIMITERS);
     }
 
+    @Override
+    public String getStrategyName() {
+        return "scheduled-executor";
+    }
 }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorWaitForTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorWaitForTimeout.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.runtime.impl.python.external;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cloudslang.runtime.api.python.ExternalPythonProcessRunService;
+import io.cloudslang.runtime.api.python.PythonEvaluationResult;
+import io.cloudslang.runtime.api.python.PythonExecutionResult;
+import io.cloudslang.runtime.impl.python.external.model.TempEnvironment;
+import io.cloudslang.runtime.impl.python.external.model.TempEvalEnvironment;
+import io.cloudslang.runtime.impl.python.external.model.TempExecutionEnvironment;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.SystemUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
+
+public class ExternalPythonExecutorWaitForTimeout implements ExternalPythonProcessRunService {
+
+    private static final Logger logger = LogManager.getLogger(ExternalPythonExecutorWaitForTimeout.class);
+    private static final String PYTHON_SCRIPT_FILENAME = "script";
+    private static final String EVAL_PY = "eval.py";
+    private static final String MAIN_PY = "main.py";
+    private static final String PYTHON_SUFFIX = ".py";
+    private static final long EXECUTION_TIMEOUT = Long.getLong("python.timeout", 30) * 60 * 1000;
+    private static final long EVALUATION_TIMEOUT = Long.getLong("python.evaluation.timeout", 3) * 60 * 1000;
+    private static final String PYTHON_FILENAME_SCRIPT_EXTENSION = ".py\"";
+    private static final int PYTHON_FILENAME_DELIMITERS = 6;
+    private static final ObjectMapper objectMapper;
+
+    static {
+        JsonFactory factory = new JsonFactory();
+        factory.enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES);
+        factory.enable(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature());
+        objectMapper = new ObjectMapper(factory);
+    }
+
+    @Override
+    public PythonExecutionResult exec(String script, Map<String, Serializable> inputs) {
+        TempExecutionEnvironment tempExecutionEnvironment = null;
+        try {
+            String pythonPath = checkPythonPath();
+            tempExecutionEnvironment = generateTempResourcesForExec(script);
+            String payload = generatePayloadForExec(tempExecutionEnvironment.getUserScriptName(), inputs);
+            addFilePermissions(tempExecutionEnvironment.getParentFolder());
+
+            return runPythonExecutionProcess(pythonPath, payload, tempExecutionEnvironment);
+
+        } catch (IOException e) {
+            String message = "Failed to generate execution resources";
+            logger.error(message, e);
+            throw new RuntimeException(message);
+        } finally {
+            if ((tempExecutionEnvironment != null) && !deleteQuietly(tempExecutionEnvironment.getParentFolder())) {
+                logger.warn(String.format("Failed to cleanup python execution resources {%s}",
+                        tempExecutionEnvironment.getParentFolder()));
+            }
+        }
+    }
+
+    @Override
+    public PythonEvaluationResult eval(String expression, String prepareEnvironmentScript,
+            Map<String, Serializable> context) {
+        return getPythonEvaluationResult(expression, prepareEnvironmentScript, context, EVALUATION_TIMEOUT);
+    }
+
+    @Override
+    public PythonEvaluationResult test(String expression, String prepareEnvironmentScript,
+            Map<String, Serializable> context, long timeout) {
+        return getPythonEvaluationResult(expression, prepareEnvironmentScript, context, timeout);
+    }
+
+    private PythonEvaluationResult getPythonEvaluationResult(String expression, String prepareEnvironmentScript,
+            Map<String, Serializable> context, long evaluationTimeout) {
+        TempEvalEnvironment tempEvalEnvironment = null;
+        try {
+            String pythonPath = checkPythonPath();
+            tempEvalEnvironment = generateTempResourcesForEval();
+            String payload = generatePayloadForEval(expression, prepareEnvironmentScript, context);
+            addFilePermissions(tempEvalEnvironment.getParentFolder());
+
+            return runPythonEvalProcess(pythonPath, payload, tempEvalEnvironment, context, evaluationTimeout);
+
+        } catch (IOException e) {
+            String message = "Failed to generate execution resources";
+            logger.error(message, e);
+            throw new RuntimeException(message);
+        } finally {
+            if ((tempEvalEnvironment != null) && !deleteQuietly(tempEvalEnvironment.getParentFolder())) {
+                logger.warn(String.format("Failed to cleanup python execution resources {%s}",
+                        tempEvalEnvironment.getParentFolder()));
+            }
+        }
+    }
+
+    private void addFilePermissions(File file) throws IOException {
+        Set<PosixFilePermission> filePermissions = new HashSet<>();
+        filePermissions.add(PosixFilePermission.OWNER_READ);
+
+        File[] fileChildren = file.listFiles();
+
+        if (fileChildren != null) {
+            for (File child : fileChildren) {
+                if (SystemUtils.IS_OS_WINDOWS) {
+                    child.setReadOnly();
+                } else {
+                    Files.setPosixFilePermissions(child.toPath(), filePermissions);
+                }
+            }
+        }
+    }
+
+    private String checkPythonPath() {
+        String pythonPath = System.getProperty("python.path");
+        if (StringUtils.isEmpty(pythonPath) || !new File(pythonPath).exists()) {
+            throw new IllegalArgumentException("Missing or invalid python path");
+        }
+        return pythonPath;
+    }
+
+    private Document parseScriptExecutionResult(String scriptExecutionResult)
+            throws IOException, ParserConfigurationException, SAXException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        InputSource is = new InputSource();
+        is.setCharacterStream(new StringReader(scriptExecutionResult));
+        return db.parse(is);
+    }
+
+    private PythonExecutionResult runPythonExecutionProcess(String pythonPath, String payload,
+            TempExecutionEnvironment executionEnvironment) {
+
+        ProcessBuilder processBuilder = preparePythonProcess(executionEnvironment, pythonPath);
+
+        try {
+            String returnResult = getResult(payload, processBuilder, EXECUTION_TIMEOUT);
+            returnResult = parseScriptExecutionResult(returnResult).getElementsByTagName("result").item(0)
+                    .getTextContent();
+            ScriptResults scriptResults = objectMapper.readValue(returnResult, ScriptResults.class);
+            String exception = formatException(scriptResults.getException(), scriptResults.getTraceback());
+
+            if (!StringUtils.isEmpty(exception)) {
+                logger.error(String.format("Failed to execute script {%s}", exception));
+                throw new ExternalPythonScriptException(String.format("Failed to execute user script: %s", exception));
+            }
+
+            //noinspection unchecked
+            return new PythonExecutionResult(scriptResults.getReturnResult());
+        } catch (IOException | InterruptedException | SAXException | ParserConfigurationException e) {
+            logger.error("Failed to run script. ", e.getCause() != null ? e.getCause() : e);
+            throw new RuntimeException("Failed to run script.");
+        }
+    }
+
+    private PythonEvaluationResult runPythonEvalProcess(String pythonPath, String payload,
+            TempEvalEnvironment executionEnvironment,
+            Map<String, Serializable> context, long timeout) {
+
+        ProcessBuilder processBuilder = preparePythonProcess(executionEnvironment, pythonPath);
+
+        try {
+            String returnResult = getResult(payload, processBuilder, timeout);
+
+            EvaluationResults scriptResults = objectMapper.readValue(returnResult, EvaluationResults.class);
+            String exception = scriptResults.getException();
+            if (!StringUtils.isEmpty(exception)) {
+                logger.error(String.format("Failed to execute script {%s}", exception));
+                throw new ExternalPythonEvalException(exception);
+            }
+            context.put("accessed_resources_set", (Serializable) scriptResults.getAccessedResources());
+            //noinspection unchecked
+            return new PythonEvaluationResult(processReturnResult(scriptResults), context);
+        } catch (IOException | InterruptedException e) {
+            logger.error("Failed to run script. ", e.getCause() != null ? e.getCause() : e);
+            throw new RuntimeException("Failed to run script.");
+        }
+    }
+
+
+    private Serializable processReturnResult(EvaluationResults results) throws JsonProcessingException {
+        EvaluationResults.ReturnType returnType = results.getReturnType();
+        if (returnType == null) {
+            throw new RuntimeException("Missing return type for return result.");
+        }
+        switch (returnType) {
+            case BOOLEAN:
+                return Boolean.valueOf(results.getReturnResult());
+            case INTEGER:
+                return Integer.valueOf(results.getReturnResult());
+            case LIST:
+                return objectMapper.readValue(results.getReturnResult(), new TypeReference<ArrayList<Serializable>>() {
+                });
+            default:
+                return results.getReturnResult();
+        }
+    }
+
+    private String getResult(final String payload, final ProcessBuilder processBuilder, final long timeoutPeriodMillis)
+            throws InterruptedException {
+        try {
+            Process process = processBuilder.start();
+
+            // Write + flush payload to process.getOutputStream()
+            PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(process.getOutputStream(), UTF_8));
+            printWriter.println(payload);
+            printWriter.flush();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+            // Timeout logic using waitFor
+            boolean finishedInTime = process.waitFor(timeoutPeriodMillis, MILLISECONDS);
+            if (!finishedInTime) { // Timeout
+                destroyProcess(process);
+                throw new RuntimeException("Timeout " + timeoutPeriodMillis + " has been reached");
+            }
+
+            // Process finished before timeout was reached, so read from process.getInputStream()
+            String line;
+            StringBuilder returnResult = new StringBuilder();
+            while ((line = reader.readLine()) != null) {
+                returnResult.append(line);
+            }
+            return returnResult.toString();
+
+        } catch (IOException ioException) {
+            throw new RuntimeException("Script execution failed: ", ioException);
+        }
+    }
+
+    private void destroyProcess(Process process) {
+        try {
+            process.destroy();
+        } catch (Exception destroyProcessExc) {
+            logger.error("Could not destroy Python process: ", destroyProcessExc);
+        }
+    }
+
+    private ProcessBuilder preparePythonProcess(TempEnvironment executionEnvironment, String pythonPath) {
+        ProcessBuilder processBuilder = new ProcessBuilder(Arrays.asList(Paths.get(pythonPath, "python").toString(),
+                Paths.get(executionEnvironment.getParentFolder().toString(), executionEnvironment.getMainScriptName())
+                        .toString()));
+        processBuilder.environment().clear();
+        processBuilder.directory(executionEnvironment.getParentFolder());
+        return processBuilder;
+    }
+
+    private TempExecutionEnvironment generateTempResourcesForExec(String script) throws IOException {
+        Path execTempDirectory = Files.createTempDirectory("python_execution");
+        File tempUserScript = File.createTempFile(PYTHON_SCRIPT_FILENAME, PYTHON_SUFFIX, execTempDirectory.toFile());
+        FileUtils.writeStringToFile(tempUserScript, script, UTF_8);
+
+        File mainScriptFile = new File(execTempDirectory.toString(), MAIN_PY);
+        FileUtils.writeByteArrayToFile(mainScriptFile, ResourceScriptResolver.loadExecScriptAsBytes());
+
+        String tempUserScriptName = FilenameUtils.getName(tempUserScript.toString());
+        return new TempExecutionEnvironment(tempUserScriptName, MAIN_PY, execTempDirectory.toFile());
+    }
+
+    private TempEvalEnvironment generateTempResourcesForEval() throws IOException {
+        Path execTempDirectory = Files.createTempDirectory("python_expression");
+        File evalScriptFile = new File(execTempDirectory.toString(), EVAL_PY);
+        FileUtils.writeByteArrayToFile(evalScriptFile, ResourceScriptResolver.loadEvalScriptAsBytes());
+
+        return new TempEvalEnvironment(EVAL_PY, execTempDirectory.toFile());
+    }
+
+    private String generatePayloadForEval(String expression, String prepareEnvironmentScript,
+            Map<String, Serializable> context) throws JsonProcessingException {
+        HashMap<String, Serializable> payload = new HashMap<>(4);
+        payload.put("expression", expression);
+        payload.put("envSetup", prepareEnvironmentScript);
+        payload.put("context", (Serializable) context);
+        return objectMapper.writeValueAsString(payload);
+    }
+
+    private String generatePayloadForExec(String userScript, Map<String, Serializable> inputs) throws
+            JsonProcessingException {
+        HashMap<String, String> parsedInputs = new HashMap<>();
+        for (Entry<String, Serializable> entry : inputs.entrySet()) {
+            parsedInputs.put(entry.getKey(), entry.getValue().toString());
+        }
+
+        Map<String, Serializable> payload = new HashMap<>(3);
+        payload.put("script_name", FilenameUtils.removeExtension(userScript));
+        payload.put("inputs", parsedInputs);
+        return objectMapper.writeValueAsString(payload);
+    }
+
+    private String formatException(String exception, List<String> traceback) {
+        return CollectionUtils.isEmpty(traceback) ? exception
+                : removeFileName(traceback.get(traceback.size() - 1)) + ", " + exception;
+    }
+
+    private String removeFileName(String trace) {
+        int pythonFileNameIndex = trace.indexOf(PYTHON_FILENAME_SCRIPT_EXTENSION);
+        return trace.substring(pythonFileNameIndex + PYTHON_FILENAME_DELIMITERS);
+    }
+
+}

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorWaitForTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorWaitForTimeout.java
@@ -263,7 +263,7 @@ public class ExternalPythonExecutorWaitForTimeout implements ExternalPythonProce
             boolean finishedInTime = process.waitFor(timeoutPeriodMillis, MILLISECONDS);
             if (!finishedInTime) { // Timeout
                 destroyProcess(process);
-                throw new RuntimeException("Timeout " + timeoutPeriodMillis + " has been reached");
+                throw new RuntimeException("Python timeout of " + timeoutPeriodMillis + " millis has been reached");
             }
 
             // Process finished before timeout was reached, so read from process.getInputStream()

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorWaitForTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorWaitForTimeout.java
@@ -63,6 +63,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import static io.cloudslang.runtime.impl.python.external.ExternalPythonExecutionEngine.WAIT_FOR_STRATEGY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.commons.io.FileUtils.deleteQuietly;
@@ -349,6 +350,6 @@ public class ExternalPythonExecutorWaitForTimeout implements ExternalPythonProce
 
     @Override
     public String getStrategyName() {
-        return "waitfor";
+        return WAIT_FOR_STRATEGY;
     }
 }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorWaitForTimeout.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonExecutorWaitForTimeout.java
@@ -347,4 +347,8 @@ public class ExternalPythonExecutorWaitForTimeout implements ExternalPythonProce
         return trace.substring(pythonFileNameIndex + PYTHON_FILENAME_DELIMITERS);
     }
 
+    @Override
+    public String getStrategyName() {
+        return "waitfor";
+    }
 }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTestRunnable.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTestRunnable.java
@@ -1,0 +1,71 @@
+package io.cloudslang.runtime.impl.python.external;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+
+public class ExternalPythonTestRunnable implements Runnable {
+
+    private final ProcessBuilder processBuilder;
+    private final String payload;
+
+    private final AtomicReference<Process> processRef;
+    private final AtomicReference<String> result;
+    private final AtomicReference<RuntimeException> exception;
+
+    public ExternalPythonTestRunnable(ProcessBuilder processBuilder, String payload) {
+        this.processBuilder = processBuilder;
+        this.payload = payload;
+
+        this.processRef = new AtomicReference<>();
+        this.result = new AtomicReference<>();
+        this.exception = new AtomicReference<>();
+    }
+
+    @Override
+    public void run() {
+        try {
+            Process process = processBuilder.start();
+            processRef.set(process);
+            PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(process.getOutputStream(), UTF_8));
+            printWriter.println(payload);
+            printWriter.flush();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            String line;
+            StringBuilder returnResult = new StringBuilder();
+            while ((line = reader.readLine()) != null) {
+                returnResult.append(line);
+            }
+            String retValue = returnResult.toString();
+            result.set(retValue);
+            exception.set(null);
+        } catch (IOException ioException) {
+            result.set(null);
+            exception.set(new RuntimeException("Script execution failed: ", ioException));
+        }
+    }
+
+    public String getResult() {
+        return result.get();
+    }
+
+    public RuntimeException getException() {
+        return exception.get();
+    }
+
+    public void destroyProcess() {
+        Process process = processRef.get();
+        if (process != null) {
+            try {
+                process.destroy();
+            } catch (Exception ignore) {
+            }
+        }
+    }
+}

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTestRunnable.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTestRunnable.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.cloudslang.runtime.impl.python.external;
 
 import java.io.BufferedReader;

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTimeoutRunnable.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTimeoutRunnable.java
@@ -35,7 +35,8 @@ public class ExternalPythonTimeoutRunnable implements Runnable {
             Process process = (Process) value;
             map.put(uniqueKey, Boolean.TRUE);
             try {
-                process.destroy();
+                // To force thread stuck in readLine() to reach IOException
+                process.getInputStream().close();
             } catch (Exception ignore) {
             }
         }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTimeoutRunnable.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTimeoutRunnable.java
@@ -1,0 +1,28 @@
+package io.cloudslang.runtime.impl.python.external;
+
+
+import java.util.concurrent.ConcurrentMap;
+
+public class ExternalPythonTimeoutRunnable implements Runnable {
+
+    private final long uniqueKey;
+    private final ConcurrentMap<Long, Object> map;
+
+    public ExternalPythonTimeoutRunnable(long uniqueKey, ConcurrentMap<Long, Object> map) {
+        this.uniqueKey = uniqueKey;
+        this.map = map;
+    }
+
+    @Override
+    public void run() {
+        Object value = map.remove(uniqueKey);
+        if (value instanceof Process) {
+            Process process = (Process) value;
+            map.put(uniqueKey, Boolean.TRUE);
+            try {
+                process.destroy();
+            } catch (Exception ignore) {
+            }
+        }
+    }
+}

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTimeoutRunnable.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTimeoutRunnable.java
@@ -16,23 +16,21 @@
 package io.cloudslang.runtime.impl.python.external;
 
 
-import java.util.concurrent.ConcurrentMap;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 
 public class ExternalPythonTimeoutRunnable implements Runnable {
 
-    private final long uniqueKey;
-    private final ConcurrentMap<Long, Boolean> map;
+    private final MutableBoolean timeoutInterrupted;
     private final Thread waitingThread;
 
-    public ExternalPythonTimeoutRunnable(long uniqueKey, ConcurrentMap<Long, Boolean> map, Thread thread) {
-        this.uniqueKey = uniqueKey;
-        this.map = map;
-        this.waitingThread = thread;
+    public ExternalPythonTimeoutRunnable(MutableBoolean timeoutInterrupted, Thread waitingThread) {
+        this.timeoutInterrupted = timeoutInterrupted;
+        this.waitingThread = waitingThread;
     }
 
     @Override
     public void run() {
-        map.put(uniqueKey, Boolean.TRUE);
+        timeoutInterrupted.setTrue();
         waitingThread.interrupt();
     }
 

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTimeoutRunnable.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTimeoutRunnable.java
@@ -35,8 +35,8 @@ public class ExternalPythonTimeoutRunnable implements Runnable {
             Process process = (Process) value;
             map.put(uniqueKey, Boolean.TRUE);
             try {
-                // To force thread stuck in readLine() to reach IOException
-                process.getInputStream().close();
+                // To force waitFor to return after timeout
+                process.destroy();
             } catch (Exception ignore) {
             }
         }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTimeoutRunnable.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTimeoutRunnable.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.cloudslang.runtime.impl.python.external;
 
 

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTimeoutRunnable.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/ExternalPythonTimeoutRunnable.java
@@ -21,24 +21,19 @@ import java.util.concurrent.ConcurrentMap;
 public class ExternalPythonTimeoutRunnable implements Runnable {
 
     private final long uniqueKey;
-    private final ConcurrentMap<Long, Object> map;
+    private final ConcurrentMap<Long, Boolean> map;
+    private final Thread waitingThread;
 
-    public ExternalPythonTimeoutRunnable(long uniqueKey, ConcurrentMap<Long, Object> map) {
+    public ExternalPythonTimeoutRunnable(long uniqueKey, ConcurrentMap<Long, Boolean> map, Thread thread) {
         this.uniqueKey = uniqueKey;
         this.map = map;
+        this.waitingThread = thread;
     }
 
     @Override
     public void run() {
-        Object value = map.remove(uniqueKey);
-        if (value instanceof Process) {
-            Process process = (Process) value;
-            map.put(uniqueKey, Boolean.TRUE);
-            try {
-                // To force waitFor to return after timeout
-                process.destroy();
-            } catch (Exception ignore) {
-            }
-        }
+        map.put(uniqueKey, Boolean.TRUE);
+        waitingThread.interrupt();
     }
+
 }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/model/TempEnvironment.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/model/TempEnvironment.java
@@ -1,0 +1,23 @@
+package io.cloudslang.runtime.impl.python.external.model;
+
+import java.io.File;
+
+public class TempEnvironment {
+
+    private final String mainScriptName;
+    private final File parentFolder;
+
+    public TempEnvironment(String mainScriptName, File parentFolder) {
+        this.mainScriptName = mainScriptName;
+        this.parentFolder = parentFolder;
+    }
+
+    public String getMainScriptName() {
+        return mainScriptName;
+    }
+
+    public File getParentFolder() {
+        return parentFolder;
+    }
+
+}

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/model/TempEnvironment.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/model/TempEnvironment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.cloudslang.runtime.impl.python.external.model;
 
 import java.io.File;

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/model/TempEvalEnvironment.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/model/TempEvalEnvironment.java
@@ -1,0 +1,12 @@
+package io.cloudslang.runtime.impl.python.external.model;
+
+import java.io.File;
+
+
+public class TempEvalEnvironment extends TempEnvironment {
+
+    public TempEvalEnvironment(String mainScriptName, File parentFolder) {
+        super(mainScriptName, parentFolder);
+    }
+
+}

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/model/TempEvalEnvironment.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/model/TempEvalEnvironment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.cloudslang.runtime.impl.python.external.model;
 
 import java.io.File;

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/model/TempExecutionEnvironment.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/model/TempExecutionEnvironment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.cloudslang.runtime.impl.python.external.model;
 
 import java.io.File;

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/model/TempExecutionEnvironment.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/external/model/TempExecutionEnvironment.java
@@ -1,0 +1,18 @@
+package io.cloudslang.runtime.impl.python.external.model;
+
+import java.io.File;
+
+
+public class TempExecutionEnvironment extends TempEnvironment {
+    private final String userScriptName;
+
+    public TempExecutionEnvironment(String userScriptName, String mainScriptName, File parentFolder) {
+        super(mainScriptName, parentFolder);
+        this.userScriptName = userScriptName;
+    }
+
+    public String getUserScriptName() {
+        return userScriptName;
+    }
+
+}


### PR DESCRIPTION
Adding 2 new timeout strategies, extracting old one as strategy
`-Dpython.timeoutStrategy=wait-for|scheduled-executor|completable-future`
This property is not present in score the default value if unspecified is `scheduled-executor`
First two strategies have a better execution performance than the `completable-future` strategy. 

Signed-off-by: Lucian Musca lucian-cristian.musca@microfocus.com