### PR TITLE
Avoid json dump errors

### DIFF
--- a/runtime-management/runtime-management-impl/src/main/resources/eval.py
+++ b/runtime-management/runtime-management-impl/src/main/resources/eval.py
@@ -144,7 +144,7 @@ class PythonAgentExecutor(object):
                 if return_type not in ['str', 'int', 'bool', 'list']:
                     return_type = 'str'
 
-                final_result = {'returnResult': expr_result,
+                final_result = {'returnResult': str(expr_result),
                                 'accessedResources': list(accessed_resources_set),
                                 'returnType': return_type}
             finally:


### PR DESCRIPTION
Wrapped the result in str to avoid errors when it would be dumped as json. Some objects were not being recognised as json serializable (complex numbers, bytearrays). Such cases would result in an empty string instead of a json being printed

Signed-off-by: Radoi Teodor teodorandrei.radoi@microfocus.com