### PR TITLE
Fixed case when str(expr_result) = None

### DIFF
--- a/runtime-management/runtime-management-impl/src/main/resources/eval.py
+++ b/runtime-management/runtime-management-impl/src/main/resources/eval.py
@@ -141,10 +141,14 @@ class PythonAgentExecutor(object):
                     expr_result = etree.tostring(expr_result, encoding='UTF-8').decode('UTF-8')
                     return_type = 'str'
 
+                else:
+                    expr_result_str = str(expr_result)
+                    expr_result = expr_result_str is not None if expr_result_str else ''
+
                 if return_type not in ['str', 'int', 'bool', 'list']:
                     return_type = 'str'
 
-                final_result = {'returnResult': str(expr_result),
+                final_result = {'returnResult': expr_result,
                                 'accessedResources': list(accessed_resources_set),
                                 'returnType': return_type}
             finally:


### PR DESCRIPTION
HttpClientInputs Keystore and trustKeystore are initialized incorrectly when expression result is None. 
It causes failure for steps like http_client_action_get:
The trust keystore provided in the 'trustKeystore' input is corrupted OR the password (in the 'trustPassword' input) is incorrect
Signed-off-by: Igor Vorobiov igor.vorobiov@microfocus.com