### PR TITLE
jython refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -420,6 +420,18 @@
                 <artifactId>lz4-java</artifactId>
                 <version>1.7.1</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.vibur</groupId>
+                <artifactId>vibur-object-pool</artifactId>
+                <version>25.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>2.9.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/runtime-management/runtime-management-impl/pom.xml
+++ b/runtime-management/runtime-management-impl/pom.xml
@@ -16,7 +16,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -110,6 +111,16 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.vibur</groupId>
+            <artifactId>vibur-object-pool</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
         </dependency>
 
     </dependencies>

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/ExecutionCachedEngine.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/ExecutionCachedEngine.java
@@ -17,9 +17,9 @@
 package io.cloudslang.runtime.impl;
 
 import io.cloudslang.dependency.api.services.DependencyService;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -65,7 +65,7 @@ public abstract class ExecutionCachedEngine<T extends Executor> extends Executio
         } finally {
             lock.unlock();
         }
-        if(candidateForRemove != null) {
+        if (candidateForRemove != null) {
             candidateForRemove.close();
         }
         return executor;
@@ -76,6 +76,8 @@ public abstract class ExecutionCachedEngine<T extends Executor> extends Executio
     }
 
     protected abstract DependencyService getDependencyService();
+
     protected abstract int getCacheSize();
+
     protected abstract T createNewExecutor(Set<String> filePaths);
 }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/EmbeddedPythonExecutorWrapper.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/EmbeddedPythonExecutorWrapper.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.runtime.impl.python;
+
+import io.cloudslang.runtime.api.python.PythonEvaluationResult;
+import io.cloudslang.runtime.api.python.PythonExecutionResult;
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.python.core.Py;
+import org.python.core.PyBoolean;
+import org.python.core.PyClass;
+import org.python.core.PyException;
+import org.python.core.PyFile;
+import org.python.core.PyFunction;
+import org.python.core.PyModule;
+import org.python.core.PyObject;
+import org.python.core.PyReflectedFunction;
+import org.python.core.PyString;
+import org.python.core.PyStringMap;
+import org.python.core.PySystemState;
+import org.python.core.PyType;
+import org.python.util.PythonInterpreter;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+public class EmbeddedPythonExecutorWrapper {
+    private static final Logger logger = LogManager.getLogger(PythonExecutor.class);
+    private static final int retriesForNoModuleFound = 3;
+    private static final String NO_MODULE_NAMED_ISSUE = "No module named";
+    private static final int exceptionMaxLength = Integer.getInteger("input.error.max.length", 1000);
+
+    private final PythonInterpreter pythonInterpreter;
+    private final AtomicBoolean closed;
+
+    public EmbeddedPythonExecutorWrapper() {
+        this(Collections.emptySet());
+    }
+
+    public EmbeddedPythonExecutorWrapper(Set<String> dependencies) {
+        this.pythonInterpreter = new PythonInterpreter(null, getPySystemState(dependencies));
+        this.closed = new AtomicBoolean(false);
+        initialize();
+    }
+
+    /**
+     * Called one time only in the lifecycle of an {@link EmbeddedPythonExecutorWrapper}
+     */
+    private void initialize() {
+        try {
+            pythonInterpreter.exec("import io");
+        } catch (Exception initException) {
+            logger.error("Could not initialize python interpreter: ", initException);
+        }
+    }
+
+    /**
+     * Contract method: Called for compiling and executing Python scripts
+     */
+    public PythonExecutionResult exec(String script, Map<String, Serializable> callArguments) {
+        validateInterpreter();
+        prepareInterpreterContext(callArguments);
+
+        Exception originalExc = null;
+        for (int i = 0; i < retriesForNoModuleFound; i++) {
+            try {
+                return doExec(script);
+            } catch (Exception exc) {
+                if (!isNoModuleFoundIssue(exc)) {
+                    throw new RuntimeException("Error executing python script: " + exc, exc);
+                }
+                if (originalExc == null) {
+                    originalExc = exc;
+                }
+            }
+        }
+        throw new RuntimeException("Error executing python script: " + originalExc, originalExc);
+    }
+
+    /**
+     * Contract method: Called for compiling and evaluating a Python expression
+     */
+    public PythonEvaluationResult eval(String prepareEnvironmentScript, String expr, Map<String, Serializable> context) {
+        validateInterpreter();
+        try {
+            prepareInterpreterContext(context);
+            Serializable eval = doEval(prepareEnvironmentScript, expr);
+            return new PythonEvaluationResult(eval, getPythonLocals());
+        } catch (PyException exception) {
+            throw new RuntimeException("Error in running script expression: '" +
+                    getTruncatedExpression(expr) + "',\n\tException is: " +
+                    handleExceptionSpecialCases(exception.value.toString()), exception);
+        } catch (Exception exception) {
+            throw new RuntimeException("Error in running script expression: '" +
+                    getTruncatedExpression(expr) + "',\n\tException is: " +
+                    handleExceptionSpecialCases(exception.getMessage()), exception);
+        }
+    }
+
+    /**
+     * Contract method: Called for closing a Python executor
+     */
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            try {
+                pythonInterpreter.close();
+            } catch (Exception ignore) {
+            }
+        }
+    }
+
+    private int getMapCapacity(int expectedSize) {
+        return (expectedSize < 3) ? (expectedSize + 1) :
+                ((expectedSize < 1073741824) ? (expectedSize + (expectedSize / 3)) : 2147483647);
+    }
+
+    private void prepareInterpreterContext(Map<String, Serializable> context) {
+        // Set a new locals map with values taken from context
+        pythonInterpreter.setLocals(new PyStringMap(getMapCapacity(context.size())));
+        for (Map.Entry<String, Serializable> entry : context.entrySet()) {
+            pythonInterpreter.set(entry.getKey(), entry.getValue());
+        }
+    }
+
+    private PythonExecutionResult doExec(String script) {
+        pythonInterpreter.exec(script);
+        return processExecResults();
+    }
+
+    private boolean isNoModuleFoundIssue(Exception e) {
+        if (e instanceof PyException) {
+            PyException pyException = (PyException) e;
+            String message = pyException.value.toString();
+            return message.contains(NO_MODULE_NAMED_ISSUE);
+        }
+        return false;
+    }
+
+    private PythonExecutionResult processExecResults() {
+        Iterator<PyObject> localsIterator = pythonInterpreter.getLocals().asIterable().iterator();
+        Map<String, Serializable> returnValue = new HashMap<>();
+        while (localsIterator.hasNext()) {
+            PyObject next = localsIterator.next();
+            String key = next.asString();
+            PyObject value = pythonInterpreter.get(key);
+            if (!isLocalEntryExcluded(key, value)) {
+                returnValue.put(key, resolveJythonObjectToJavaForExec(value, key));
+            }
+        }
+        return new PythonExecutionResult(returnValue);
+    }
+
+    private Serializable resolveJythonObjectToJavaForExec(PyObject value, String key) {
+        String errorMessage =
+                "Non-serializable values are not allowed in the output context of a Python script:\n" +
+                        "\tConversion failed for '" + key + "' (" + value + "),\n" +
+                        "\tThe error can be solved by removing the variable from the context in the script: e.g. 'del " + key + "'.\n";
+        return resolveJythonObjectToJava(value, errorMessage);
+    }
+
+    private Serializable resolveJythonObjectToJavaForEval(PyObject value, String expression) {
+        String errorMessage =
+                "Evaluation result for a Python expression should be serializable:\n" +
+                        "\tConversion failed for '" + expression + "' (" + value + ").\n";
+        return resolveJythonObjectToJava(value, errorMessage);
+    }
+
+    private Serializable resolveJythonObjectToJava(PyObject value, String errorMessage) {
+        if (value == null) {
+            return null;
+        } else if (value instanceof PyBoolean) {
+            PyBoolean pyBoolean = (PyBoolean) value;
+            return pyBoolean.getBooleanValue();
+        } else {
+            try {
+                return Py.tojava(value, Serializable.class);
+            } catch (PyException pyException) {
+                PyObject typeObject = pyException.type;
+                if (typeObject instanceof PyType) {
+                    PyType type = (PyType) typeObject;
+                    String typeName = type.getName();
+                    if ("TypeError".equals(typeName)) {
+                        throw new RuntimeException(errorMessage, pyException);
+                    }
+                }
+                throw pyException;
+            }
+        }
+    }
+
+    private boolean isLocalEntryExcluded(String key, PyObject value) {
+        return (key.startsWith("__") && key.endsWith("__")) ||
+                value instanceof PyFile ||
+                value instanceof PyModule ||
+                value instanceof PyFunction ||
+                value instanceof PySystemState ||
+                value instanceof PyClass ||
+                value instanceof PyType ||
+                value instanceof PyReflectedFunction;
+    }
+
+    private Map<String, Serializable> getPythonLocals() {
+        Map<String, Serializable> retVal = new HashMap<>();
+        for (PyObject pyObject : pythonInterpreter.getLocals().asIterable()) {
+            String key = pyObject.asString();
+            PyObject value = pythonInterpreter.get(key);
+            if (!isLocalEntryExcluded(key, value)) {
+                retVal.put(key, value);
+            }
+        }
+        return retVal;
+    }
+
+    private String getTruncatedExpression(String expr) {
+        return expr.length() > exceptionMaxLength ? expr.substring(0, exceptionMaxLength) + "..." : expr;
+    }
+
+    private String handleExceptionSpecialCases(String message) {
+        String processedMessage = message;
+        if (StringUtils.isNotEmpty(message) && message.contains("get_sp") && message.contains("not defined")) {
+            processedMessage = message + ". Make sure to use correct syntax for the function: " +
+                    "get_sp('fully.qualified.name', optional_default_value).";
+        }
+        return processedMessage;
+    }
+
+    private void validateInterpreter() {
+        if (closed.get()) {
+            throw new RuntimeException("Trying to execute Python code on an already closed interpreter");
+        }
+    }
+
+    private Serializable doEval(String prepareEnvironmentScript, String script) {
+        // Set boolean values
+        pythonInterpreter.set("true", Boolean.TRUE);
+        pythonInterpreter.set("false", Boolean.FALSE);
+        // Prepare environment if required
+        if (isNotEmpty(prepareEnvironmentScript)) {
+            pythonInterpreter.exec(prepareEnvironmentScript);
+        }
+        PyObject evalResultPyObject = pythonInterpreter.eval(script);
+        return resolveJythonObjectToJavaForEval(evalResultPyObject, script);
+    }
+
+    private PySystemState getPySystemState(Set<String> dependencies) {
+        PySystemState pySystemState = new PySystemState();
+        if (!dependencies.isEmpty()) {
+            for (String dependency : dependencies) {
+                pySystemState.path.append(new PyString(dependency));
+            }
+        }
+        return pySystemState;
+    }
+
+}

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/EmbeddedPythonExecutorWrapper.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/EmbeddedPythonExecutorWrapper.java
@@ -17,7 +17,7 @@ package io.cloudslang.runtime.impl.python;
 
 import io.cloudslang.runtime.api.python.PythonEvaluationResult;
 import io.cloudslang.runtime.api.python.PythonExecutionResult;
-import io.cloudslang.runtime.impl.python.security.BoundStringWriter;
+import io.cloudslang.runtime.impl.python.security.BoundedStringWriter;
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -89,8 +89,8 @@ public class EmbeddedPythonExecutorWrapper {
      */
     public PythonExecutionResult exec(String script, Map<String, Serializable> callArguments) {
         validateInterpreter();
-        Writer outputWriter = new BoundStringWriter(outputStreamLengthExceededSupplier);
-        Writer errorWriter = new BoundStringWriter(errorStreamLengthExceededSupplier);
+        Writer outputWriter = new BoundedStringWriter(outputStreamLengthExceededSupplier);
+        Writer errorWriter = new BoundedStringWriter(errorStreamLengthExceededSupplier);
         try {
             pythonInterpreter.setOut(outputWriter);
             pythonInterpreter.setErr(errorWriter);

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonExecutionCachedEngine.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonExecutionCachedEngine.java
@@ -30,7 +30,11 @@ import java.util.Set;
 import static java.util.Collections.emptySet;
 
 /**
- * Created by Genadi Rabinovich, genadi@hpe.com on 05/05/2016.
+ * Please prefer io.cloudslang.runtime.impl.python.PythonExecutionPooledAndCachedEngine instead of this implementation
+ * because of enhanced functionality and security in the former.
+ * Works with io.cloudslang.runtime.impl.python.PythonExecutor that uses ThreadLocal state
+ * and a shared PythonExecutor.GLOBAL_INTERPRETER for no depedencies python.
+ * Uses a cache of PythonExecutor for python with dependencies.
  */
 public class PythonExecutionCachedEngine extends ExecutionCachedEngine<PythonExecutor> implements PythonExecutionEngine {
     @Autowired

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonExecutionEngine.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonExecutionEngine.java
@@ -27,9 +27,11 @@ import java.util.Set;
  * Created by Genadi Rabinovich, genadi@hpe.com on 05/05/2016.
  */
 public interface PythonExecutionEngine {
+
     PythonExecutionResult exec(Set<String> dependencies, String script, Map<String, Serializable> vars);
 
     PythonEvaluationResult eval(String prepareEnvironmentScript, String script, Map<String, Serializable> vars);
 
     PythonEvaluationResult test(String prepareEnvironmentScript, String script, Map<String, Serializable> vars, long timeout);
+
 }

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonExecutionEngineConfiguration.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonExecutionEngineConfiguration.java
@@ -57,11 +57,11 @@ public class PythonExecutionEngineConfiguration {
 
         String value = System.getProperty(PYTHON_EXECUTOR_ENGINE, pooledAndCachedEngine);
 
-        if (StringUtils.equals(value, pooledAndCachedEngine)) {
+        if (StringUtils.equalsIgnoreCase(value, pooledAndCachedEngine)) {
             return new PythonExecutionPooledAndCachedEngine();
-        } else if (StringUtils.equals(value, cacheEngine)) {
+        } else if (StringUtils.equalsIgnoreCase(value, cacheEngine)) {
             return new PythonExecutionCachedEngine();
-        } else if (StringUtils.equals(value, simpleEngine)) {
+        } else if (StringUtils.equalsIgnoreCase(value, simpleEngine)) {
             return new PythonExecutionNotCachedEngine();
         } else {
             return new PythonExecutionPooledAndCachedEngine();

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonExecutionEngineConfiguration.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonExecutionEngineConfiguration.java
@@ -20,12 +20,15 @@ import io.cloudslang.dependency.impl.services.DependenciesManagementConfiguratio
 import io.cloudslang.runtime.api.python.PythonRuntimeService;
 import io.cloudslang.runtime.impl.python.external.ExternalPythonExecutionEngine;
 import io.cloudslang.runtime.impl.python.external.ExternalPythonRuntimeServiceImpl;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import java.util.concurrent.Semaphore;
+
+import static io.cloudslang.runtime.impl.python.PythonExecutionConfigurationConsts.PYTHON_EXECUTOR_ENGINE;
 
 /**
  * Created by Genadi Rabinovich, genadi@hpe.com on 05/05/2016.
@@ -48,10 +51,21 @@ public class PythonExecutionEngineConfiguration {
 
     @Bean(name = "jythonExecutionEngine")
     PythonExecutionEngine pythonExecutionEngine() {
-        String noCacheEngine = PythonExecutionNotCachedEngine.class.getSimpleName();
+        String pooledAndCachedEngine = PythonExecutionPooledAndCachedEngine.class.getSimpleName();
         String cacheEngine = PythonExecutionCachedEngine.class.getSimpleName();
-        return System.getProperty(PythonExecutionConfigurationConsts.PYTHON_EXECUTOR_ENGINE, cacheEngine).equals(noCacheEngine) ?
-                new PythonExecutionNotCachedEngine() : new PythonExecutionCachedEngine();
+        String simpleEngine = PythonExecutionNotCachedEngine.class.getSimpleName();
+
+        String value = System.getProperty(PYTHON_EXECUTOR_ENGINE, pooledAndCachedEngine);
+
+        if (StringUtils.equals(value, pooledAndCachedEngine)) {
+            return new PythonExecutionPooledAndCachedEngine();
+        } else if (StringUtils.equals(value, cacheEngine)) {
+            return new PythonExecutionCachedEngine();
+        } else if (StringUtils.equals(value, simpleEngine)) {
+            return new PythonExecutionNotCachedEngine();
+        } else {
+            return new PythonExecutionPooledAndCachedEngine();
+        }
     }
 
     @Bean(name = "externalPythonExecutionEngine")

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonExecutionPooledAndCachedEngine.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonExecutionPooledAndCachedEngine.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudslang.runtime.impl.python;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.cloudslang.dependency.api.services.DependencyService;
+import io.cloudslang.runtime.api.python.PythonEvaluationResult;
+import io.cloudslang.runtime.api.python.PythonExecutionResult;
+import io.cloudslang.runtime.impl.ExecutionEngine;
+import io.cloudslang.runtime.impl.python.pool.ViburEmbeddedPythonPoolService;
+import io.cloudslang.runtime.impl.python.pool.ViburEmbeddedPythonPoolServiceImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
+
+import static java.lang.Integer.getInteger;
+
+/**
+ * Uses io.cloudslang.runtime.impl.python.EmbeddedPythonExecutorWrapper that brings more security
+ * than io.cloudslang.runtime.impl.python.PythonExecutor
+ * For python that has no dependencies, it uses a pool of EmbeddedPythonExecutorWrapper instances,
+ * that are totally isolated not using ThreadLocal at all.
+ * For python with dependencies, it uses a dedicated cache of EmbeddedPythonExecutorWrapper.
+ */
+public class PythonExecutionPooledAndCachedEngine extends ExecutionEngine implements PythonExecutionEngine {
+
+    @Autowired
+    private DependencyService dependencyService;
+
+    @Autowired
+    @Qualifier("numberOfExecutionThreads")
+    private Integer numberOfThreads;
+
+    private ViburEmbeddedPythonPoolService pythonExecutorPool;
+    private Cache<String, EmbeddedPythonExecutorWrapper> cachedExecutors;
+
+    @PostConstruct
+    public void init() {
+        this.pythonExecutorPool = new ViburEmbeddedPythonPoolServiceImpl(numberOfThreads);
+        this.cachedExecutors = Caffeine.newBuilder()
+                .maximumSize(getInteger("jython.executor.cacheSize", numberOfThreads * 4 / 3))
+                .build();
+    }
+
+    @Override
+    public PythonExecutionResult exec(Set<String> dependencies, String script, Map<String, Serializable> vars) {
+        Set<String> resultedDependencies = dependencyService.getDependencies(dependencies);
+        // When dependencies are not set we take an EmbeddedPythonExecutorWrapper from the 'pythonExecutorPool' pool
+        // When dependencies are set we take an EmbeddedPythonExecutorWrapper from the 'cachedExecutors' cache
+        if (resultedDependencies.isEmpty()) {
+            EmbeddedPythonExecutorWrapper pooledPythonExecutor = null;
+            try {
+                pooledPythonExecutor = pythonExecutorPool.tryTakeWithTimeout();
+                return pooledPythonExecutor.exec(script, vars);
+            } finally {
+                doRestoreExecutor(pooledPythonExecutor);
+            }
+        } else {
+            String dependenciesKey = generatedDependenciesKey(dependencies);
+            EmbeddedPythonExecutorWrapper executor = cachedExecutors.getIfPresent(dependenciesKey);
+            if (executor == null) {
+                EmbeddedPythonExecutorWrapper newPythonExecutor = new EmbeddedPythonExecutorWrapper(resultedDependencies);
+                executor = cachedExecutors.get(dependenciesKey, k -> newPythonExecutor);
+            }
+            // At this point executor cannot be null, since it was created in in the function  k -> newPythonExecutor
+            // That is the reason we don't want to call an extra Objects.requireNotNull(executor)
+            return executor.exec(script, vars);
+        }
+    }
+
+    @Override
+    public PythonEvaluationResult eval(String prepareEnvironmentScript, String script, Map<String, Serializable> vars) {
+        EmbeddedPythonExecutorWrapper embeddedPythonExecutor = null;
+        try {
+            embeddedPythonExecutor = pythonExecutorPool.tryTakeWithTimeout();
+            return embeddedPythonExecutor.eval(prepareEnvironmentScript, script, vars);
+        } finally {
+            doRestoreExecutor(embeddedPythonExecutor);
+        }
+    }
+
+    @Override
+    public PythonEvaluationResult test(String prepareEnvironmentScript, String script,
+                                       Map<String, Serializable> vars, long timeout) {
+        EmbeddedPythonExecutorWrapper embeddedPythonExecutor = null;
+        try {
+            embeddedPythonExecutor = pythonExecutorPool.tryTakeWithTimeout();
+            // For Jython test is identical with eval
+            return embeddedPythonExecutor.eval(prepareEnvironmentScript, script, vars);
+        } finally {
+            doRestoreExecutor(embeddedPythonExecutor);
+        }
+    }
+
+    private void doRestoreExecutor(EmbeddedPythonExecutorWrapper pooledPythonExecutor) {
+        try {
+            pythonExecutorPool.restore(pooledPythonExecutor);
+        } catch (Exception ignored) {
+        }
+    }
+
+    @PreDestroy
+    public void closeResources() {
+        pythonExecutorPool.close();
+        try {
+            cachedExecutors.asMap().values().forEach(EmbeddedPythonExecutorWrapper::close);
+        } catch (Exception ignored) {
+        }
+    }
+
+}

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonRuntimeServiceImpl.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/PythonRuntimeServiceImpl.java
@@ -19,7 +19,6 @@ package io.cloudslang.runtime.impl.python;
 import io.cloudslang.runtime.api.python.PythonEvaluationResult;
 import io.cloudslang.runtime.api.python.PythonExecutionResult;
 import io.cloudslang.runtime.api.python.PythonRuntimeService;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.annotation.Resource;
 import java.io.Serializable;

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/pool/ViburEmbeddedPythonFactory.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/pool/ViburEmbeddedPythonFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.runtime.impl.python.pool;
+
+
+import io.cloudslang.runtime.impl.python.EmbeddedPythonExecutorWrapper;
+import org.vibur.objectpool.PoolObjectFactory;
+
+public class ViburEmbeddedPythonFactory implements PoolObjectFactory<EmbeddedPythonExecutorWrapper> {
+
+    public ViburEmbeddedPythonFactory() {
+    }
+
+    @Override
+    public EmbeddedPythonExecutorWrapper create() {
+        return new EmbeddedPythonExecutorWrapper();
+    }
+
+    @Override
+    public boolean readyToTake(EmbeddedPythonExecutorWrapper pythonExecutorWrapper) {
+        return true;
+    }
+
+    @Override
+    public boolean readyToRestore(EmbeddedPythonExecutorWrapper pythonExecutorWrapper) {
+        return true;
+    }
+
+    @Override
+    public void destroy(EmbeddedPythonExecutorWrapper pythonExecutorWrapper) {
+        pythonExecutorWrapper.close();
+    }
+
+}

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/pool/ViburEmbeddedPythonPoolService.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/pool/ViburEmbeddedPythonPoolService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.runtime.impl.python.pool;
+
+
+import io.cloudslang.runtime.impl.python.EmbeddedPythonExecutorWrapper;
+
+public interface ViburEmbeddedPythonPoolService {
+
+    EmbeddedPythonExecutorWrapper tryTakeWithTimeout();
+
+    void restore(EmbeddedPythonExecutorWrapper poolable);
+
+    void close();
+
+}

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/pool/ViburEmbeddedPythonPoolServiceImpl.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/pool/ViburEmbeddedPythonPoolServiceImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.runtime.impl.python.pool;
+
+
+import io.cloudslang.runtime.impl.python.EmbeddedPythonExecutorWrapper;
+import org.vibur.objectpool.ConcurrentPool;
+import org.vibur.objectpool.util.ConcurrentLinkedQueueCollection;
+
+import static java.lang.Integer.getInteger;
+import static java.lang.Long.getLong;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class ViburEmbeddedPythonPoolServiceImpl implements ViburEmbeddedPythonPoolService {
+
+    private final ConcurrentPool<EmbeddedPythonExecutorWrapper> poolService;
+    private final long timeout;
+
+    public ViburEmbeddedPythonPoolServiceImpl(int numberOfThreads) {
+        final int minPoolSize = getInteger("jython.executor.minPoolSize", numberOfThreads);
+        final int maxPoolSize = getInteger("jython.executor.maxPoolSize", numberOfThreads);
+        this.poolService = new ConcurrentPool<>(new ConcurrentLinkedQueueCollection<>(),
+                new ViburEmbeddedPythonFactory(),
+                minPoolSize,
+                maxPoolSize,
+                false);
+        this.timeout = getLong("jython.executor.checkoutTimeoutSeconds", 10 * 60L); // 10 minutes
+    }
+
+    @Override
+    public EmbeddedPythonExecutorWrapper tryTakeWithTimeout() {
+        return poolService.tryTake(timeout, SECONDS);
+    }
+
+    @Override
+    public void restore(EmbeddedPythonExecutorWrapper pooledObject) {
+        poolService.restore(pooledObject);
+    }
+
+    @Override
+    public void close() {
+        try {
+            poolService.close();
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/security/BoundStringWriter.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/security/BoundStringWriter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2014-2017 EntIT Software LLC, a Micro Focus company (L.P.)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.runtime.impl.python.security;
+
+import java.io.StringWriter;
+import java.util.function.Supplier;
+
+public class BoundStringWriter extends StringWriter {
+    private static final int defaultMaxChars = Integer.getInteger("jython.standardStreams.maxLength", 1000);
+    private static final int nullStringLength = 4;
+
+    private final Supplier<RuntimeException> exceptionSupplier;
+    private final int maxChars;
+
+    public BoundStringWriter(Supplier<RuntimeException> exceptionSupplier) {
+        super();
+        this.maxChars = defaultMaxChars;
+        this.exceptionSupplier = exceptionSupplier;
+    }
+
+    @Override
+    public void write(int c) {
+        validateBounds(1);
+        super.write(c);
+    }
+
+    @Override
+    public void write(char[] charArray, int off, int len) {
+        if (len > 0) {
+            validateBounds(len);
+        }
+        super.write(charArray, off, len);
+    }
+
+    @Override
+    public void write(String str) {
+        validateBounds((str == null) ? nullStringLength : str.length()); // in case of null the string "null" is added
+        super.write(str);
+    }
+
+    @Override
+    public void write(String str, int off, int len) {
+        if (len > 0) {
+            validateBounds(len);
+        }
+        super.write(str, off, len);
+    }
+
+    @Override
+    public StringWriter append(CharSequence csq) {
+        validateBounds((csq == null) ? nullStringLength : csq.length()); // in case of null the string "null" is added
+        return super.append(csq);
+    }
+
+    @Override
+    public StringWriter append(CharSequence csq, int start, int end) {
+        validateBounds((csq == null) ? nullStringLength : csq.subSequence(start, end).length());
+        return super.append(csq, start, end);
+    }
+
+    @Override
+    public StringWriter append(char c) {
+        validateBounds(1);
+        return super.append(c);
+    }
+
+    private void validateBounds(int toAddNumberOfChars) {
+        if ((getBuffer().length() + toAddNumberOfChars) > maxChars) {
+            throw exceptionSupplier.get();
+        }
+    }
+
+}

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/security/BoundStringWriter.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/security/BoundStringWriter.java
@@ -20,7 +20,7 @@ import java.util.function.Supplier;
 
 public class BoundStringWriter extends StringWriter {
     private static final int defaultMaxChars = Integer.getInteger("jython.standardStreams.maxLength", 1000);
-    private static final int nullStringLength = 4;
+    private static final int nullStringLength = "null".length();
 
     private final Supplier<RuntimeException> exceptionSupplier;
     private final int maxChars;

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/security/BoundedStringWriter.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/security/BoundedStringWriter.java
@@ -18,14 +18,14 @@ package io.cloudslang.runtime.impl.python.security;
 import java.io.StringWriter;
 import java.util.function.Supplier;
 
-public class BoundStringWriter extends StringWriter {
+public class BoundedStringWriter extends StringWriter {
     private static final int defaultMaxChars = Integer.getInteger("jython.standardStreams.maxLength", 1000);
     private static final int nullStringLength = "null".length();
 
     private final Supplier<RuntimeException> exceptionSupplier;
     private final int maxChars;
 
-    public BoundStringWriter(Supplier<RuntimeException> exceptionSupplier) {
+    public BoundedStringWriter(Supplier<RuntimeException> exceptionSupplier) {
         super();
         this.maxChars = defaultMaxChars;
         this.exceptionSupplier = exceptionSupplier;

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/security/BoundedStringWriter.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/security/BoundedStringWriter.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
  * when attempting to write more than 'maxChars' characters to the buffer
  */
 public class BoundedStringWriter extends StringWriter {
+
     private static final int defaultMaxChars = Integer.getInteger("jython.standardStreams.maxLength", 1000);
     private static final int nullStringLength = "null".length();
 

--- a/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/security/BoundedStringWriter.java
+++ b/runtime-management/runtime-management-impl/src/main/java/io/cloudslang/runtime/impl/python/security/BoundedStringWriter.java
@@ -18,6 +18,10 @@ package io.cloudslang.runtime.impl.python.security;
 import java.io.StringWriter;
 import java.util.function.Supplier;
 
+/**
+ * Basic implementation of a java.io.Writer than throws RuntimeException
+ * when attempting to write more than 'maxChars' characters to the buffer
+ */
 public class BoundedStringWriter extends StringWriter {
     private static final int defaultMaxChars = Integer.getInteger("jython.standardStreams.maxLength", 1000);
     private static final int nullStringLength = "null".length();


### PR DESCRIPTION
- do not use jython threadlocal locals inside engine threadpool, change of strategy
By default the argument passed for jython strategy is `-Dpython.executor.engine=PythonExecutionPooledAndCachedEngine`
- use dedicated pool for jython executors to handle jython content without dependencies 
- use dedicated cache for jython executors to handle jython content with dependencies 
- better security for jython standard streams handling

Signed-off-by: Lucian Musca lucian-cristian.musca@microfocus.com