### PR TITLE
Execute flow in debug mode even if worker group is not valid.

### DIFF
--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/SimpleExecutionRunnable.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/SimpleExecutionRunnable.java
@@ -335,6 +335,11 @@ public class SimpleExecutionRunnable implements Runnable {
         }
     }
 
+    private boolean isDebuggerMode(Execution execution) {
+        return execution.getSystemContext().containsKey(TempConstants.DEBUGGER_MODE)
+                && (Boolean)execution.getSystemContext().get(TempConstants.DEBUGGER_MODE);
+    }
+
     private boolean shouldChangeWorkerGroup(Execution nextStepExecution) {
         // Here we check if we can continue to run in current thread - depends on the group
         if (nextStepExecution.getSystemContext().shouldCheckGroup()) {
@@ -350,7 +355,7 @@ public class SimpleExecutionRunnable implements Runnable {
             boolean canRunInThisWorker = (groupName == null)
                     || workerConfigurationService.isMemberOf(groupName) || isStickyToThisWorker(groupName);
 
-            if (!canRunInThisWorker) {
+            if (!canRunInThisWorker && !isDebuggerMode(nextStepExecution)) {
                 //set current step to finished
                 executionMessage.setStatus(ExecStatus.FINISHED);
                 executionMessage.incMsgSeqId();

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/SimpleExecutionRunnable.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/SimpleExecutionRunnable.java
@@ -337,7 +337,7 @@ public class SimpleExecutionRunnable implements Runnable {
 
     private boolean isDebuggerMode(Execution execution) {
         return execution.getSystemContext().containsKey(TempConstants.DEBUGGER_MODE)
-                && (Boolean)execution.getSystemContext().get(TempConstants.DEBUGGER_MODE);
+                && (Boolean) execution.getSystemContext().get(TempConstants.DEBUGGER_MODE);
     }
 
     private boolean shouldChangeWorkerGroup(Execution nextStepExecution) {


### PR DESCRIPTION
There are cases when executing a flow in debug mode and we get invalid (expression) worker group details.
In this case, we want the flow to ignore the worker group and execute flow normally.