### PR TITLE
check if branch exists already

### DIFF
--- a/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/entities/FinishedBranch.java
+++ b/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/entities/FinishedBranch.java
@@ -75,11 +75,7 @@ public class FinishedBranch extends AbstractIdentifiable {
 
     public boolean connectToSuspendedExecution(SuspendedExecution suspendedExecution) {
         this.suspendedExecution = suspendedExecution;
-        if (!suspendedExecution.getFinishedBranches().contains(this)) {
-            suspendedExecution.getFinishedBranches().add(this); //bi directional connection
-            return true;
-        }
-        return false;
+        return suspendedExecution.getFinishedBranches().add(this); //bi directional connection
     }
 
     public SuspendedExecution getSuspendedExecution() {

--- a/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/entities/FinishedBranch.java
+++ b/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/entities/FinishedBranch.java
@@ -73,9 +73,13 @@ public class FinishedBranch extends AbstractIdentifiable {
         this.branchContexts = branchContexts;
     }
 
-    public void connectToSuspendedExecution(SuspendedExecution suspendedExecution) {
+    public boolean connectToSuspendedExecution(SuspendedExecution suspendedExecution) {
         this.suspendedExecution = suspendedExecution;
-        suspendedExecution.getFinishedBranches().add(this); //bi directional connection
+        if (!suspendedExecution.getFinishedBranches().contains(this)) {
+            suspendedExecution.getFinishedBranches().add(this); //bi directional connection
+            return true;
+        }
+        return false;
     }
 
     public SuspendedExecution getSuspendedExecution() {

--- a/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/entities/SuspendedExecution.java
+++ b/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/entities/SuspendedExecution.java
@@ -20,9 +20,17 @@ import io.cloudslang.orchestrator.enums.SuspendedExecutionReason;
 import io.cloudslang.score.facade.entities.Execution;
 import io.cloudslang.engine.data.AbstractIdentifiable;
 
-import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Enumerated;
+import javax.persistence.Basic;
+import javax.persistence.Embedded;
+import javax.persistence.OneToMany;
+import javax.persistence.CascadeType;
+import javax.persistence.FetchType;
+import java.util.HashSet;
+import java.util.Set;
 
 import static javax.persistence.EnumType.STRING;
 
@@ -62,7 +70,7 @@ public class SuspendedExecution extends AbstractIdentifiable {
     private ExecutionObjEntity executionObj;
 
     @OneToMany(cascade = {CascadeType.ALL}, orphanRemoval = true, fetch = FetchType.LAZY, mappedBy="suspendedExecution")
-    private List<FinishedBranch> finishedBranches = new ArrayList<>();
+    private Set<FinishedBranch> finishedBranches = new HashSet<>();
 
     private SuspendedExecution() {
     }
@@ -117,11 +125,11 @@ public class SuspendedExecution extends AbstractIdentifiable {
         this.executionObj = new ExecutionObjEntity(executionObj);
     }
 
-    public List<FinishedBranch> getFinishedBranches() {
+    public Set<FinishedBranch> getFinishedBranches() {
         return finishedBranches;
     }
 
-    public void setFinishedBranches(List<FinishedBranch> finishedBranches) {
+    public void setFinishedBranches(Set<FinishedBranch> finishedBranches) {
         this.finishedBranches = finishedBranches;
     }
 

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/SplitJoinServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/SplitJoinServiceImpl.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static ch.lambdaj.Lambda.convert;
 import static ch.lambdaj.Lambda.extract;
@@ -333,7 +334,7 @@ public final class SplitJoinServiceImpl implements SplitJoinService {
             execution.getSystemContext().remove(FINISHED_CHILD_BRANCHES_DATA);
             execution.getSystemContext().put("CURRENT_PROCESSED__SPLIT_ID", se.getSplitId());
             joinMiSplit(se, execution);
-            List<FinishedBranch> finishedBranches = se.getFinishedBranches();
+            Set<FinishedBranch> finishedBranches = se.getFinishedBranches();
             long nrOfNewFinishedBranches = finishedBranches.stream()
                     .filter(finishedBranch -> !finishedBranch.getBranchContexts().isBranchCancelled())
                     .count();
@@ -385,7 +386,7 @@ public final class SplitJoinServiceImpl implements SplitJoinService {
 
     private Execution joinSplit(SuspendedExecution suspendedExecution) {
 
-        List<FinishedBranch> finishedBranches = suspendedExecution.getFinishedBranches();
+        Set<FinishedBranch> finishedBranches = suspendedExecution.getFinishedBranches();
         Execution exec = suspendedExecution.getExecutionObj();
 
         Validate.isTrue(suspendedExecution.getNumberOfBranches().equals(finishedBranches.size()),
@@ -415,7 +416,7 @@ public final class SplitJoinServiceImpl implements SplitJoinService {
     }
 
     private void joinMiSplit(SuspendedExecution suspendedExecution, Execution exec) {
-        List<FinishedBranch> finishedBranches = suspendedExecution.getFinishedBranches();
+        Set<FinishedBranch> finishedBranches = suspendedExecution.getFinishedBranches();
 
         if (logger.isDebugEnabled()) {
             logger.debug("Joining execution " + exec.getExecutionId());

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/SplitJoinServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/SplitJoinServiceImpl.java
@@ -230,15 +230,15 @@ public final class SplitJoinServiceImpl implements SplitJoinService {
 
             SuspendedExecution suspendedExecution = suspendedMap.get(finishedBranch.getSplitId());
             if (suspendedExecution != null) {
-                finishedBranch.connectToSuspendedExecution(suspendedExecution);
+                boolean shouldProcessBranch = finishedBranch.connectToSuspendedExecution(suspendedExecution);
                 if (suspendedExecution.getSuspensionReason() == MULTI_INSTANCE) {
                     // start a new branch
                     if (!finishedBranch.getBranchContexts().isBranchCancelled()) {
                         startNewBranch(suspendedExecution);
                     }
-                    processFinishedBranch(finishedBranch, suspendedExecution, suspendedExecutionsForMiWithOneBranch);
+                    processFinishedBranch(finishedBranch, suspendedExecution, suspendedExecutionsForMiWithOneBranch, shouldProcessBranch);
                 } else {
-                    processFinishedBranch(finishedBranch, suspendedExecution, suspendedExecutionsWithOneBranch);
+                    processFinishedBranch(finishedBranch, suspendedExecution, suspendedExecutionsWithOneBranch, shouldProcessBranch);
                 }
             }
         }
@@ -259,10 +259,11 @@ public final class SplitJoinServiceImpl implements SplitJoinService {
 
     private void processFinishedBranch(FinishedBranch finishedBranch,
                                        SuspendedExecution suspendedExecution,
-                                       List<SuspendedExecution> suspendedExecutionsWithOneBranch) {
+                                       List<SuspendedExecution> suspendedExecutionsWithOneBranch,
+                                       boolean shouldProcessBranch) {
         if (suspendedExecution.getNumberOfBranches() == 1) {
             suspendedExecutionsWithOneBranch.add(suspendedExecution);
-        } else {
+        } else if (shouldProcessBranch) {
             finishedBranchRepository.save(finishedBranch);
         }
     }

--- a/engine/orchestrator/score-orchestrator-impl/src/test/java/io/cloudslang/orchestrator/repositories/SuspendedExecutionsRepositoryTest.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/test/java/io/cloudslang/orchestrator/repositories/SuspendedExecutionsRepositoryTest.java
@@ -112,7 +112,7 @@ public class SuspendedExecutionsRepositoryTest {
 
         SuspendedExecution suspendedExecutionRead = read.get(0);
         Assert.assertTrue(suspendedExecutionRead.getFinishedBranches().size() == 1);
-        Assert.assertTrue(suspendedExecutionRead.getFinishedBranches().get(0).getSplitId().equals("888"));
+        Assert.assertTrue(suspendedExecutionRead.getFinishedBranches().iterator().next().getSplitId().equals("888"));
     }
 
     @Test

--- a/engine/orchestrator/score-orchestrator-impl/src/test/java/io/cloudslang/orchestrator/services/SplitJoinServiceTest.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/test/java/io/cloudslang/orchestrator/services/SplitJoinServiceTest.java
@@ -234,8 +234,8 @@ public class SplitJoinServiceTest {
 
         List<EndBranchDataContainer> finishedChildContexts = value.getSystemContext().getFinishedChildBranchesData();
 
-        Map<String, Serializable> ooContexts = suspendedExecution.getFinishedBranches().get(0).getBranchContexts().getContexts();
-        Map<String, Serializable> systemContext = suspendedExecution.getFinishedBranches().get(0).getBranchContexts().getSystemContext();
+        Map<String, Serializable> ooContexts = suspendedExecution.getFinishedBranches().iterator().next().getBranchContexts().getContexts();
+        Map<String, Serializable> systemContext = suspendedExecution.getFinishedBranches().iterator().next().getBranchContexts().getSystemContext();
         assertThat("parent execution must contain children maps", finishedChildContexts, is(Arrays.asList(
                 new EndBranchDataContainer(ooContexts, systemContext, null))));
     }


### PR DESCRIPTION
If one of the branch would fail for parallel or multi instance flow, the entity would be saved in database. 
If the user would cancel the flow, all the branches would be saved in database even the previous branch that failed. That would result in an exception: unique key validation for branchId and splitId. 

Signed-off-by: Larisa Bratean <larisa-alexandra.bratean@microfocus.com>