### PR TITLE
Busyness feature disable NPE

### DIFF
--- a/worker/worker-monitor/score-worker-monitor-impl/src/main/java/io/cloudslang/worker/monitor/PerformanceMetricsCollector.java
+++ b/worker/worker-monitor/score-worker-monitor-impl/src/main/java/io/cloudslang/worker/monitor/PerformanceMetricsCollector.java
@@ -31,6 +31,7 @@ import oshi.software.os.OSProcess;
 
 import javax.annotation.PostConstruct;
 import java.io.Serializable;
+import java.lang.Boolean;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -67,7 +68,10 @@ public class PerformanceMetricsCollector implements PerfMetricCollector {
     private OSProcess oldProcess;
 
     public PerformanceMetricsCollector() {
-        this.oldProcess = getProcess();
+        boolean isDisabled = Boolean.getBoolean("worker.monitoring.disable");
+        if (!isDisabled) {
+            this.oldProcess = getProcess();
+        }
     }
 
     @PostConstruct

--- a/worker/worker-monitor/score-worker-monitor-impl/src/main/java/io/cloudslang/worker/monitor/mbean/WorkerMetricsMBean.java
+++ b/worker/worker-monitor/score-worker-monitor-impl/src/main/java/io/cloudslang/worker/monitor/mbean/WorkerMetricsMBean.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
 import oshi.software.os.OSProcess;
+import java.lang.Boolean;
 
 import static io.cloudslang.worker.monitor.metric.WorkerPerfMetric.getProcess;
 
@@ -55,9 +56,12 @@ public class WorkerMetricsMBean {
     private OSProcess prevDiskWriteProcess;
 
     public WorkerMetricsMBean() {
-        this.prevCpuProcess = getProcess();
-        this.prevDiskReadProcess = getProcess();
-        this.prevDiskWriteProcess = getProcess();
+        boolean isDisabled = Boolean.getBoolean("worker.monitoring.disable");
+        if (!isDisabled) {
+            this.prevCpuProcess = getProcess();
+            this.prevDiskReadProcess = getProcess();
+            this.prevDiskWriteProcess = getProcess();
+        }
     }
 
     @ManagedAttribute(description = "Current Cpu Usage")


### PR DESCRIPTION
The RAS workers were crashing even after worker busyness feature is disabled. 