### PR TITLE
add safety check before micro step and check pending license

### DIFF
--- a/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/services/QueueListenerImplTest.java
+++ b/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/services/QueueListenerImplTest.java
@@ -78,6 +78,9 @@ public class QueueListenerImplTest {
 	@Autowired
 	private SplitJoinService splitJoinService;
 
+	@Autowired
+	private QueueDispatcherService queueDispatcherService;
+
 	@Before
 	public void setup() throws IOException {
 		reset(eventBus);
@@ -238,6 +241,11 @@ public class QueueListenerImplTest {
 		@Bean
 		PauseResumeService pauseResumeService() {
 			return mock(PauseResumeService.class);
+		}
+
+		@Bean
+		QueueDispatcherService queueDispatcherService() {
+			return mock(QueueDispatcherService.class);
 		}
 	}
 


### PR DESCRIPTION
Add safety check to not checkout license if the flow is canceled
In case the pause execution for no license gets executed after the pending cancel of the flow because of the job, ignore the pause of execution and dispatch the messages for pending cancel