### PR TITLE
Fix shutdown of service for locks

### DIFF
--- a/worker/worker-manager/score-worker-manager-api/src/main/java/io/cloudslang/worker/management/services/SynchronizationManager.java
+++ b/worker/worker-manager/score-worker-manager-api/src/main/java/io/cloudslang/worker/management/services/SynchronizationManager.java
@@ -40,4 +40,6 @@ public interface SynchronizationManager {
 
     void startDrain();
     void finishDrain();
+
+    void unlockOnShutdown();
 }

--- a/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/SynchronizationManagerImpl.java
+++ b/worker/worker-manager/score-worker-manager-impl/src/main/java/io/cloudslang/worker/management/services/SynchronizationManagerImpl.java
@@ -82,6 +82,13 @@ public class SynchronizationManagerImpl implements SynchronizationManager {
     }
 
     @Override
+    public void unlockOnShutdown() {
+        outBufferLock.lock();
+        notEmpty.signalAll();
+        unlockCompletely(outBufferLock);
+    }
+
+    @Override
     public void startDrain() {
         if (logger.isDebugEnabled()) {
             logger.debug("In SynchronizationManager.startDrain()");


### PR DESCRIPTION
In case of spring closing, the notEmpty condition was still in await state resulting in delay in the shutdown of service.
To be able to fix it, we lock the ReentrantLock to be able to signal the notEmpty condition, and unlock it at the end.