### PR TITLE
clean stale entries from suspended executions and finished branches

### DIFF
--- a/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/SplitJoinService.java
+++ b/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/SplitJoinService.java
@@ -64,4 +64,6 @@ public interface SplitJoinService {
     void joinFinishedSplits();
 
     int joinFinishedMiBranches(int bulkSize);
+
+    void deleteStaleSuspendedExecutions(long finishedExecutionEndTime);
 }

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/repositories/FinishedBranchRepository.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/repositories/FinishedBranchRepository.java
@@ -36,4 +36,8 @@ public interface FinishedBranchRepository extends JpaRepository<FinishedBranch, 
     @Query("delete from FinishedBranch fe where fe.id in :ids")
     @Modifying
     void deleteByIds(@Param("ids") Collection<Long> ids);
+
+    @Query("delete from FinishedBranch fe where fe.executionId in :executionIds")
+    @Modifying
+    void deleteByExecutionIds(@Param("executionIds") Collection<String> executionIds);
 }

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/repositories/SuspendedExecutionsRepository.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/repositories/SuspendedExecutionsRepository.java
@@ -50,6 +50,15 @@ public interface SuspendedExecutionsRepository extends JpaRepository<SuspendedEx
     @Query("from SuspendedExecution se where se.splitId = cast(:splitId as string)")
     SuspendedExecution findBySplitId(@Param("splitId") String splitId);
 
+    @Query("from SuspendedExecution se where se.locked = true")
+    List<SuspendedExecution> findPotentialStaleSuspendedExecution();
+
+    @Query(value = "SELECT execution_id FROM oo_execution_summary WHERE status IN (:suspensionReasons) AND" +
+            " execution_id IN (:executionIds) AND end_time_long < :time", nativeQuery = true)
+    List<String> findCancelledExecutionInOOExecutionSummaryTable(@Param("suspensionReasons") List<String> suspensionReasons,
+                                                                 @Param("executionIds") List<String> executionIds,
+                                                                 @Param("time") long time);
+
     @Modifying
     @Query("update SuspendedExecution se set se.executionObj = :newExecution, se.locked = false where se.id = :suspendedExecutionId")
     void updateSuspendedExecutionContexts(@Param("suspendedExecutionId") long suspendedExecutionId,

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/SplitJoinServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/SplitJoinServiceImpl.java
@@ -338,7 +338,7 @@ public final class SplitJoinServiceImpl implements SplitJoinService {
             List<String> cancelledExecutions = suspendedExecutionsRepository.findCancelledExecutionInOOExecutionSummaryTable(
                     statusEnums.stream().map(Enum::name).collect(Collectors.toList()), executionIds, timeLimitMillis);
 
-            finishedBranchRepository.deleteByExecutionIds(executionIds);
+            finishedBranchRepository.deleteByExecutionIds(cancelledExecutions);
             suspendedExecutionsRepository.deleteByIds(cancelledExecutions);
         }
     }

--- a/engine/score-engine-jobs/src/main/java/io/cloudslang/job/ScoreEngineJobsImpl.java
+++ b/engine/score-engine-jobs/src/main/java/io/cloudslang/job/ScoreEngineJobsImpl.java
@@ -69,6 +69,10 @@ public class ScoreEngineJobsImpl implements ScoreEngineJobs {
 
     private final Integer SPLIT_JOIN_ITERATIONS = Integer.getInteger("splitjoin.job.iterations", 20);
 
+    private static final long FINISHED_EXECUTION_END_TIME = Long.getLong("splitjoin.job.finished.execution.end.time", 3 * 60 * 60 * 1000L); // 3 hours
+
+
+
     /**
      * Job that will handle the cleaning of queue table.
      */
@@ -114,6 +118,8 @@ public class ScoreEngineJobsImpl implements ScoreEngineJobs {
                 int joinedSplits = splitJoinService.joinFinishedSplits(SPLIT_JOIN_BULK_SIZE);
                 moreToJoin = (joinedSplits == SPLIT_JOIN_BULK_SIZE);
             }
+
+            splitJoinService.deleteStaleSuspendedExecutions(FINISHED_EXECUTION_END_TIME);
 
             stopWatch.stop();
             if (logger.isDebugEnabled()) logger.debug("finished SplitJoinJob in " + stopWatch);


### PR DESCRIPTION
- Implemented a check to delete entries from oo_suspended_executions and oo_finished_branches when an MI branch is canceled.

- Added logic to remove stale entries from oo_suspended_executions and oo_finished_branches at the end of a split-join job if the execution has ended (CANCELED or FINISHED in oo_execution_summary) and the end time was at least 3 hours ago (configurable).