### PR TITLE
Enhance the engine queue cleanup mechanism

### DIFF
--- a/engine/orchestrator/score-orchestrator-api/pom.xml
+++ b/engine/orchestrator/score-orchestrator-api/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>querydsl-jpa</artifactId>
             <classifier>jakarta</classifier>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-jpa</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/ExecutionCleanerService.java
+++ b/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/ExecutionCleanerService.java
@@ -15,6 +15,6 @@
  */
 package io.cloudslang.orchestrator.services;
 
-public interface FinishedExecutionStateCleanerService {
-    void cleanFinishedExecutionState();
+public interface ExecutionCleanerService {
+    void cleanExecutions();
 }

--- a/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateService.java
+++ b/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateService.java
@@ -19,6 +19,7 @@ package io.cloudslang.orchestrator.services;
 import io.cloudslang.score.facade.entities.Execution;
 import io.cloudslang.score.facade.execution.ExecutionStatus;
 import io.cloudslang.orchestrator.entities.ExecutionState;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.Date;
 import java.util.List;
@@ -103,8 +104,9 @@ public interface ExecutionStateService {
      * @param executionId id of the execution
      * @param branchId id of the branch
      * @param status  status of the execution
+     * @param updateDate update time of the execution
      */
-    public void updateExecutionStateStatus(Long executionId, String branchId, ExecutionStatus status);
+    public void updateExecutionStateStatus(Long executionId, String branchId, ExecutionStatus status, Date updateDate);
 
     /**
      * Deletes the specified execution, both the parent execution and any child executions
@@ -117,5 +119,8 @@ public interface ExecutionStateService {
     public void deleteCanceledExecutionStates();
 
     public Execution getExecutionObjectForNullBranch(Long executionId);
-    public void updateExecutionStateStatus(Long executionId, String branchId, ExecutionStatus status, Date updateDate);
+
+    List<Long> findExecutionStateByStatusInAndUpdateTimeLessThanEqual(List<ExecutionStatus> statuses, long time, PageRequest pageRequest);
+
+    void deleteExecutionStateByIds(List<Long> ids);
 }

--- a/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateService.java
+++ b/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateService.java
@@ -95,7 +95,7 @@ public interface ExecutionStateService {
      * @param branchId    id of the branch
      * @param execution   the execution object
      */
-    public void updateExecutionObject(Long executionId, String branchId, Execution execution);
+    public void updateExecutionObject(Long executionId, String branchId, Execution execution, Date updateDate);
 
     /***
      * Updates the status for the given execution id and branch id

--- a/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateService.java
+++ b/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateService.java
@@ -120,7 +120,7 @@ public interface ExecutionStateService {
 
     public Execution getExecutionObjectForNullBranch(Long executionId);
 
-    List<Long> findExecutionStateByStatusInAndUpdateTimeLessThanEqual(List<ExecutionStatus> statuses, long time, PageRequest pageRequest);
+    List<Long> findExecutionStateByStatusInAndUpdateTimeLessThanEqual(List<ExecutionStatus> statuses, Long time, PageRequest pageRequest);
 
     void deleteExecutionStateByIds(List<Long> ids);
 }

--- a/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateService.java
+++ b/engine/orchestrator/score-orchestrator-api/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateService.java
@@ -120,7 +120,7 @@ public interface ExecutionStateService {
 
     public Execution getExecutionObjectForNullBranch(Long executionId);
 
-    List<Long> findExecutionStateByStatusInAndUpdateTimeLessThanEqual(List<ExecutionStatus> statuses, Long time, PageRequest pageRequest);
+    public List<Long> findExecutionStateByStatusInAndUpdateTimeLessThanEqual(List<ExecutionStatus> statuses, long cutOffTime, PageRequest pageRequest);
 
-    void deleteExecutionStateByIds(List<Long> ids);
+    public void deleteExecutionStateByIds(List<Long> toDeleteIds);
 }

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionCleanerServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionCleanerServiceImpl.java
@@ -93,13 +93,8 @@ public class ExecutionCleanerServiceImpl implements ExecutionCleanerService {
             List<Long> idList = new ArrayList<>(ids);
             List<List<Long>> partitions = Lists.partition(idList, SPLIT_SIZE);
 
-            int processedEntries = 0;
             for (List<Long> partition : partitions) {
-                if (processedEntries >= MAX_BULK_SIZE) {
-                    break;
-                }
                 queueCleanerService.cleanUnusedSteps(new HashSet<>(partition));
-                processedEntries += partition.size();
             }
         } catch (Exception exception) {
             logger.error("Unused executions cleanup job failed: ", exception);

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionCleanerServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionCleanerServiceImpl.java
@@ -16,9 +16,7 @@
 package io.cloudslang.orchestrator.services;
 
 import io.cloudslang.engine.queue.entities.ExecutionStatesData;
-import io.cloudslang.engine.queue.repositories.ExecutionQueueRepository;
 import io.cloudslang.engine.queue.services.cleaner.QueueCleanerService;
-import io.cloudslang.orchestrator.repositories.ExecutionStateRepository;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,12 +27,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.springframework.transaction.annotation.Transactional;
 import static io.cloudslang.score.facade.execution.ExecutionStatus.*;
 import static java.util.Arrays.asList;
 import static org.springframework.util.CollectionUtils.isEmpty;
 
-public class FinishedExecutionStateCleanerServiceImpl implements FinishedExecutionStateCleanerService {
+public class ExecutionCleanerServiceImpl implements ExecutionCleanerService {
 
     private final int MAX_BULK_SIZE = Integer.getInteger("execution.state.clean.job.bulk.size", 200);
     final private int QUEUE_BULK_SIZE = 500;
@@ -42,60 +39,46 @@ public class FinishedExecutionStateCleanerServiceImpl implements FinishedExecuti
     private static final long EXECUTION_STATE_INACTIVE_TIME = 5 * 60 * 1000L;
     private static final long ORPHAN_EXECUTION_QUEUES_INACTIVE_TIME = 10 * 60 * 1000L;
 
-    private static final Logger logger = LogManager.getLogger(FinishedExecutionStateCleanerServiceImpl.class);
+    private static final Logger logger = LogManager.getLogger(ExecutionCleanerServiceImpl.class);
 
     @Autowired
-    private ExecutionStateRepository executionStateRepository;
-
-    @Autowired
-    private ExecutionQueueRepository executionQueueRepository;
+    private ExecutionStateService executionStateService;
 
     @Autowired
     private QueueCleanerService queueCleanerService;
 
     @Override
-    @Transactional
-    public void cleanFinishedExecutionState() {
+    // @Transactional
+    public void cleanExecutions() {
         try {
-            // cleanFinishedExecutionState(MAX_BULK_SIZE);
-            cleanFinishedStateAndQueues(MAX_BULK_SIZE);
+            performExecutionCleanup(MAX_BULK_SIZE);
         } catch (Exception e) {
-            logger.error("Finished execution state cleaner job failed!", e);
+            logger.error("Execution cleanup job failed!", e);
         }
     }
 
-    private void cleanFinishedExecutionState(Integer bulkSize) {
-        long timeLimitMillis = System.currentTimeMillis() - EXECUTION_STATE_INACTIVE_TIME;
+    private void performExecutionCleanup(Integer bulkSize) {
+        // safely delete execution queues and state mappings for non-latest or unused states
+        // from oo_execution_states and oo_execution_queues
+        deleteUnusedExecutionStatesAndQueues();
 
-        for (int i = 1; i <= bulkSize / SPLIT_SIZE; i++) {
-            PageRequest pageRequest = PageRequest.of(0, SPLIT_SIZE);
-            List<Long> toBeDeleted = executionStateRepository.findByStatusInAndUpdateTimeLessThanEqual(asList(CANCELED, COMPLETED, SYSTEM_FAILURE), timeLimitMillis, pageRequest);
+        // remove all finished executions and related data (CANCELED, COMPLETED, SYSTEM_FAILURE)
+        // from oo_execution_queues, oo_execs_states_execs_mappings, oo_execution_states and oo_execution_state
+        deleteFinalizedExecutionData(bulkSize);
 
-            if (!isEmpty(toBeDeleted)) {
-                executionStateRepository.deleteByIds(toBeDeleted);
-            }
-
-        }
-
-    }
-
-    private void cleanFinishedStateAndQueues(Integer bulkSize) {
-        // delete incrementally from oo_execution_states, oo_execution_queues and oo_execs_states_execs_mappings
-        deleteIncrementallyFromExecutionQueues();
-
-        // delete from oo_execution_states, oo_execution_queues, oo_execs_states_execs_mappings, oo_execution_state
-        // where oo_execution_state.status is finished (CANCELED, COMPLETED, SYSTEM_FAILURE)
-        deleteFinishedExecutionsFromAllTables(bulkSize);
-
-        // delete orphan oo_execution_queues which are left over from multi instance, blocking and parallel step execution
+        // Clean up orphaned queue entries left from parallel or multi-instance execution from oo_execution_queues
         deleteOrphanExecutionQueues();
-
-        // delete from suspended_executions and finished_executions
     }
 
-    private void deleteIncrementallyFromExecutionQueues() {
+    private void deleteUnusedExecutionStatesAndQueues() {
         try {
-            List<ExecutionStatesData> latestExecutionStateData = executionQueueRepository.getLatestExecutionStates();
+            Set<Long> ids = queueCleanerService.getFinishedExecStateIds();
+            if (logger.isDebugEnabled()) {
+                logger.debug("Will clean from queue the next execution state ids amount: " + ids.size());
+            }
+            logger.warn("Will clean from queue the next execution state ids amount: " + ids.size());
+
+            List<ExecutionStatesData> latestExecutionStateData = queueCleanerService.getLatestExecutionStates();
             if (logger.isDebugEnabled()) {
                 String execStates = latestExecutionStateData.stream()
                         .map(ExecutionStatesData::toString)
@@ -106,38 +89,31 @@ public class FinishedExecutionStateCleanerServiceImpl implements FinishedExecuti
                     .map(ExecutionStatesData::toString)
                     .collect(Collectors.joining(", "));
             logger.warn("Latest execution states before cleaning job: " + execStates);
-
-            Set<Long> ids = queueCleanerService.getFinishedExecStateIds();
-            if (logger.isDebugEnabled()) {
-                logger.debug("Will clean from queue the next execution state ids amount: " + ids.size());
-            }
-            logger.warn("Will clean from queue the next execution state ids amount: " + ids.size());
-
             Set<Long> execIds = new HashSet<>();
 
             for (Long id : ids) {
                 execIds.add(id);
                 if (execIds.size() >= QUEUE_BULK_SIZE) {
-                    queueCleanerService.cleanFinishedSteps(execIds);
+                    queueCleanerService.cleanUnusedSteps(execIds);
                     execIds.clear();
                 }
             }
 
             if (execIds.size() > 0) {
-                queueCleanerService.cleanFinishedSteps(execIds);
+                queueCleanerService.cleanUnusedSteps(execIds);
             }
         } catch (Exception e) {
             logger.error("Can't run queue cleaner job.", e);
         }
     }
 
-    private void deleteFinishedExecutionsFromAllTables(Integer bulkSize) {
+    private void deleteFinalizedExecutionData(Integer bulkSize) {
         long timeLimitMillis = System.currentTimeMillis() - EXECUTION_STATE_INACTIVE_TIME;
 
         for (int i = 1; i <= bulkSize / SPLIT_SIZE; i++) {
             PageRequest pageRequest = PageRequest.of(0, SPLIT_SIZE);
-            List<Long> finishedStateIds = executionStateRepository
-                    .findByStatusInAndUpdateTimeLessThanEqual(asList(CANCELED, COMPLETED, SYSTEM_FAILURE),
+            List<Long> finishedStateIds = executionStateService
+                    .findExecutionStateByStatusInAndUpdateTimeLessThanEqual(asList(CANCELED, COMPLETED, SYSTEM_FAILURE),
                             timeLimitMillis, pageRequest);
             if (logger.isDebugEnabled()) {
                 logger.debug("Will clean from queue and states the next finished execution state ids amount: "
@@ -147,19 +123,19 @@ public class FinishedExecutionStateCleanerServiceImpl implements FinishedExecuti
                     + finishedStateIds.size());
 
             if (!isEmpty(finishedStateIds)) {
-                Set<Long> finishedStatesQueuesIds = executionQueueRepository
+                Set<Long> finishedStatesQueuesIds = queueCleanerService
                         .getExecutionStatesByFinishedMessageId(new HashSet<>(finishedStateIds));
 
-                executionQueueRepository.deleteFinishedSteps(finishedStatesQueuesIds);
-                executionStateRepository.deleteByIds(finishedStateIds);
+                queueCleanerService.cleanFinishedSteps(finishedStatesQueuesIds);
+                executionStateService.deleteExecutionStateByIds(finishedStateIds);
             }
         }
     }
 
     private void deleteOrphanExecutionQueues() {
         long timeLimitMillisOrphanExecutionQueues = System.currentTimeMillis() - ORPHAN_EXECUTION_QUEUES_INACTIVE_TIME;
-        Set<Long> orphanExecutionQueuesIds = executionQueueRepository
-                .getOrphanExecutionQueues(timeLimitMillisOrphanExecutionQueues);
+        Set<Long> orphanExecutionQueuesIds = queueCleanerService
+                .getOrphanQueues(timeLimitMillisOrphanExecutionQueues);
         if (logger.isDebugEnabled()) {
             String orphanIds = orphanExecutionQueuesIds.stream()
                             .map(String::valueOf)
@@ -173,6 +149,6 @@ public class FinishedExecutionStateCleanerServiceImpl implements FinishedExecuti
         logger.warn("Will clean from queue the orphan amount: " + orphanExecutionQueuesIds.size());
         logger.warn("Will clean from queue the following orphans: " + orphanIds);
 
-        executionQueueRepository.deleteOrphanExecutionQueuesById(orphanExecutionQueuesIds);
+        queueCleanerService.cleanOrphanQueues(orphanExecutionQueuesIds);
     }
 }

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionCleanerServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionCleanerServiceImpl.java
@@ -74,7 +74,7 @@ public class ExecutionCleanerServiceImpl implements ExecutionCleanerService {
 
     private void deleteUnusedExecutionStatesAndQueues() {
         try {
-            Set<Long> ids = queueCleanerService.getFinishedExecStateIds();
+            Set<Long> ids = queueCleanerService.getNonLatestFinishedExecStateIds();
             if (logger.isDebugEnabled()) {
                 logger.debug("Will clean from queue the next execution state ids amount: " + ids.size());
             }

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateServiceImpl.java
@@ -131,11 +131,12 @@ public class ExecutionStateServiceImpl implements ExecutionStateService {
 
     @Override
     @Transactional
-    public void updateExecutionObject(Long executionId, String branchId, Execution execution) {
+    public void updateExecutionObject(Long executionId, String branchId, Execution execution, Date updateDate) {
         validateExecutionId(executionId);
         validateBranchId(branchId);
         ExecutionState executionState = findByExecutionIdAndBranchId(executionId, branchId);
         executionState.setExecutionObject(executionSerializationUtil.objToBytes(execution));
+        executionState.setUpdateTime(updateDate.getTime());
     }
 
     @Override

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateServiceImpl.java
@@ -25,6 +25,7 @@ import io.cloudslang.score.facade.execution.ExecutionStatus;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
@@ -103,6 +104,7 @@ public class ExecutionStateServiceImpl implements ExecutionStateService {
     }
 
     @Override
+    @Transactional
     public void updateExecutionStateStatus(Long executionId, String branchId, ExecutionStatus status,
                                            Date updateDate) {
         validateExecutionId(executionId);
@@ -137,16 +139,6 @@ public class ExecutionStateServiceImpl implements ExecutionStateService {
         ExecutionState executionState = findByExecutionIdAndBranchId(executionId, branchId);
         executionState.setExecutionObject(executionSerializationUtil.objToBytes(execution));
         executionState.setUpdateTime(updateDate.getTime());
-    }
-
-    @Override
-    @Transactional
-    public void updateExecutionStateStatus(Long executionId, String branchId, ExecutionStatus status) {
-        validateExecutionId(executionId);
-        validateBranchId(branchId);
-        Validate.notNull(status, "status cannot be null");
-        ExecutionState executionState = findByExecutionIdAndBranchId(executionId, branchId);
-        executionState.setStatus(status);
     }
 
     private ExecutionState findByExecutionIdAndBranchId(Long executionId, String branchId) {
@@ -196,6 +188,18 @@ public class ExecutionStateServiceImpl implements ExecutionStateService {
         } else {
             return null;
         }
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Long> findExecutionStateByStatusInAndUpdateTimeLessThanEqual(List<ExecutionStatus> statuses, long time, PageRequest pageRequest) {
+        return executionStateRepository.findByStatusInAndUpdateTimeLessThanEqual(statuses, time, pageRequest);
+    }
+
+    @Transactional
+    @Override
+    public void deleteExecutionStateByIds(List<Long> ids) {
+        executionStateRepository.deleteByIds(ids);
     }
 
     private void validateBranchId(String branchId) {

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateServiceImpl.java
@@ -192,14 +192,14 @@ public class ExecutionStateServiceImpl implements ExecutionStateService {
 
     @Transactional(readOnly = true)
     @Override
-    public List<Long> findExecutionStateByStatusInAndUpdateTimeLessThanEqual(List<ExecutionStatus> statuses, Long time, PageRequest pageRequest) {
-        return executionStateRepository.findByStatusInAndUpdateTimeLessThanEqual(statuses, time, pageRequest);
+    public List<Long> findExecutionStateByStatusInAndUpdateTimeLessThanEqual(List<ExecutionStatus> statuses, long cutOffTime, PageRequest pageRequest) {
+        return executionStateRepository.findByStatusInAndUpdateTimeLessThanEqual(statuses, cutOffTime, pageRequest);
     }
 
     @Transactional
     @Override
-    public void deleteExecutionStateByIds(List<Long> ids) {
-        executionStateRepository.deleteByIds(ids);
+    public void deleteExecutionStateByIds(List<Long> toDeleteIds) {
+        executionStateRepository.deleteByIds(toDeleteIds);
     }
 
     private void validateBranchId(String branchId) {

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/ExecutionStateServiceImpl.java
@@ -192,7 +192,7 @@ public class ExecutionStateServiceImpl implements ExecutionStateService {
 
     @Transactional(readOnly = true)
     @Override
-    public List<Long> findExecutionStateByStatusInAndUpdateTimeLessThanEqual(List<ExecutionStatus> statuses, long time, PageRequest pageRequest) {
+    public List<Long> findExecutionStateByStatusInAndUpdateTimeLessThanEqual(List<ExecutionStatus> statuses, Long time, PageRequest pageRequest) {
         return executionStateRepository.findByStatusInAndUpdateTimeLessThanEqual(statuses, time, pageRequest);
     }
 

--- a/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/FinishedExecutionStateCleanerServiceImpl.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/main/java/io/cloudslang/orchestrator/services/FinishedExecutionStateCleanerServiceImpl.java
@@ -15,13 +15,20 @@
  */
 package io.cloudslang.orchestrator.services;
 
+import io.cloudslang.engine.queue.entities.ExecutionStatesData;
+import io.cloudslang.engine.queue.repositories.ExecutionQueueRepository;
+import io.cloudslang.engine.queue.services.cleaner.QueueCleanerService;
 import io.cloudslang.orchestrator.repositories.ExecutionStateRepository;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.springframework.transaction.annotation.Transactional;
 import static io.cloudslang.score.facade.execution.ExecutionStatus.*;
 import static java.util.Arrays.asList;
@@ -30,21 +37,30 @@ import static org.springframework.util.CollectionUtils.isEmpty;
 public class FinishedExecutionStateCleanerServiceImpl implements FinishedExecutionStateCleanerService {
 
     private final int MAX_BULK_SIZE = Integer.getInteger("execution.state.clean.job.bulk.size", 200);
+    final private int QUEUE_BULK_SIZE = 500;
     private final int SPLIT_SIZE = 200;
-    private static final long EXECUTION_STATE_INACTIVE_TIME = 30 * 60 * 1000L;
+    private static final long EXECUTION_STATE_INACTIVE_TIME = 5 * 60 * 1000L;
+    private static final long ORPHAN_EXECUTION_QUEUES_INACTIVE_TIME = 10 * 60 * 1000L;
 
     private static final Logger logger = LogManager.getLogger(FinishedExecutionStateCleanerServiceImpl.class);
 
     @Autowired
     private ExecutionStateRepository executionStateRepository;
 
+    @Autowired
+    private ExecutionQueueRepository executionQueueRepository;
+
+    @Autowired
+    private QueueCleanerService queueCleanerService;
+
     @Override
     @Transactional
     public void cleanFinishedExecutionState() {
         try {
-            cleanFinishedExecutionState(MAX_BULK_SIZE);
+            // cleanFinishedExecutionState(MAX_BULK_SIZE);
+            cleanFinishedStateAndQueues(MAX_BULK_SIZE);
         } catch (Exception e) {
-            logger.error("finished execution state cleaner job failed!", e);
+            logger.error("Finished execution state cleaner job failed!", e);
         }
     }
 
@@ -61,5 +77,102 @@ public class FinishedExecutionStateCleanerServiceImpl implements FinishedExecuti
 
         }
 
+    }
+
+    private void cleanFinishedStateAndQueues(Integer bulkSize) {
+        // delete incrementally from oo_execution_states, oo_execution_queues and oo_execs_states_execs_mappings
+        deleteIncrementallyFromExecutionQueues();
+
+        // delete from oo_execution_states, oo_execution_queues, oo_execs_states_execs_mappings, oo_execution_state
+        // where oo_execution_state.status is finished (CANCELED, COMPLETED, SYSTEM_FAILURE)
+        deleteFinishedExecutionsFromAllTables(bulkSize);
+
+        // delete orphan oo_execution_queues which are left over from multi instance, blocking and parallel step execution
+        deleteOrphanExecutionQueues();
+
+        // delete from suspended_executions and finished_executions
+    }
+
+    private void deleteIncrementallyFromExecutionQueues() {
+        try {
+            List<ExecutionStatesData> latestExecutionStateData = executionQueueRepository.getLatestExecutionStates();
+            if (logger.isDebugEnabled()) {
+                String execStates = latestExecutionStateData.stream()
+                        .map(ExecutionStatesData::toString)
+                        .collect(Collectors.joining(", "));
+                logger.debug("Latest execution states before cleaning job: " + execStates);
+            }
+            String execStates = latestExecutionStateData.stream()
+                    .map(ExecutionStatesData::toString)
+                    .collect(Collectors.joining(", "));
+            logger.warn("Latest execution states before cleaning job: " + execStates);
+
+            Set<Long> ids = queueCleanerService.getFinishedExecStateIds();
+            if (logger.isDebugEnabled()) {
+                logger.debug("Will clean from queue the next execution state ids amount: " + ids.size());
+            }
+            logger.warn("Will clean from queue the next execution state ids amount: " + ids.size());
+
+            Set<Long> execIds = new HashSet<>();
+
+            for (Long id : ids) {
+                execIds.add(id);
+                if (execIds.size() >= QUEUE_BULK_SIZE) {
+                    queueCleanerService.cleanFinishedSteps(execIds);
+                    execIds.clear();
+                }
+            }
+
+            if (execIds.size() > 0) {
+                queueCleanerService.cleanFinishedSteps(execIds);
+            }
+        } catch (Exception e) {
+            logger.error("Can't run queue cleaner job.", e);
+        }
+    }
+
+    private void deleteFinishedExecutionsFromAllTables(Integer bulkSize) {
+        long timeLimitMillis = System.currentTimeMillis() - EXECUTION_STATE_INACTIVE_TIME;
+
+        for (int i = 1; i <= bulkSize / SPLIT_SIZE; i++) {
+            PageRequest pageRequest = PageRequest.of(0, SPLIT_SIZE);
+            List<Long> finishedStateIds = executionStateRepository
+                    .findByStatusInAndUpdateTimeLessThanEqual(asList(CANCELED, COMPLETED, SYSTEM_FAILURE),
+                            timeLimitMillis, pageRequest);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Will clean from queue and states the next finished execution state ids amount: "
+                        + finishedStateIds.size());
+            }
+            logger.warn("Will clean from queue and states the next finished execution state ids amount: "
+                    + finishedStateIds.size());
+
+            if (!isEmpty(finishedStateIds)) {
+                Set<Long> finishedStatesQueuesIds = executionQueueRepository
+                        .getExecutionStatesByFinishedMessageId(new HashSet<>(finishedStateIds));
+
+                executionQueueRepository.deleteFinishedSteps(finishedStatesQueuesIds);
+                executionStateRepository.deleteByIds(finishedStateIds);
+            }
+        }
+    }
+
+    private void deleteOrphanExecutionQueues() {
+        long timeLimitMillisOrphanExecutionQueues = System.currentTimeMillis() - ORPHAN_EXECUTION_QUEUES_INACTIVE_TIME;
+        Set<Long> orphanExecutionQueuesIds = executionQueueRepository
+                .getOrphanExecutionQueues(timeLimitMillisOrphanExecutionQueues);
+        if (logger.isDebugEnabled()) {
+            String orphanIds = orphanExecutionQueuesIds.stream()
+                            .map(String::valueOf)
+                            .collect(Collectors.joining(", "));
+            logger.debug("Will clean from queue the orphan amount: " + orphanExecutionQueuesIds.size());
+            logger.debug("Will clean from queue the following orphans: " + orphanIds);
+        }
+        String orphanIds = orphanExecutionQueuesIds.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(", "));
+        logger.warn("Will clean from queue the orphan amount: " + orphanExecutionQueuesIds.size());
+        logger.warn("Will clean from queue the following orphans: " + orphanIds);
+
+        executionQueueRepository.deleteOrphanExecutionQueuesById(orphanExecutionQueuesIds);
     }
 }

--- a/engine/orchestrator/score-orchestrator-impl/src/test/java/io/cloudslang/orchestrator/services/ExecutionStateServiceTest.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/test/java/io/cloudslang/orchestrator/services/ExecutionStateServiceTest.java
@@ -337,35 +337,35 @@ public class ExecutionStateServiceTest {
     @Test
     public void testUpdateExecutionStateStatus_NullExecutionId() {
         IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
-                () -> executionStateService.updateExecutionStateStatus(null, "Asdfsdf", null));
+                () -> executionStateService.updateExecutionStateStatus(null, "Asdfsdf", null, new Date()));
         Assert.assertEquals("executionId cannot be null or empty", exception.getMessage());
     }
 
     @Test
     public void testUpdateExecutionStateStatus_EmptyExecutionId() {
         IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
-                () -> executionStateService.updateExecutionStateStatus(null, "Asdfsdf", null));
+                () -> executionStateService.updateExecutionStateStatus(null, "Asdfsdf", null, new Date()));
         Assert.assertEquals("executionId cannot be null or empty", exception.getMessage());
     }
 
     @Test
     public void testUpdateExecutionStateStatus_NullBranchId() {
         IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
-                () -> executionStateService.updateExecutionStateStatus(123L, null, null));
+                () -> executionStateService.updateExecutionStateStatus(123L, null, null, new Date()));
         Assert.assertEquals("branchId cannot be null or empty", exception.getMessage());
     }
 
     @Test
     public void testUpdateExecutionStateStatus_EmptyBranchId() {
         IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
-                () -> executionStateService.updateExecutionStateStatus(123L, "          ", null));
+                () -> executionStateService.updateExecutionStateStatus(123L, "          ", null, new Date()));
         Assert.assertEquals("branchId cannot be null or empty", exception.getMessage());
     }
 
     @Test
     public void testUpdateExecutionStateStatus_NullStatus() {
         IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
-                () -> executionStateService.updateExecutionStateStatus(123L, "asdasd", null));
+                () -> executionStateService.updateExecutionStateStatus(123L, "asdasd", null, new Date()));
         Assert.assertEquals("status cannot be null", exception.getMessage());
     }
 
@@ -379,7 +379,7 @@ public class ExecutionStateServiceTest {
 
         when(executionStateRepository.findByExecutionIdAndBranchId(executionId, branchId)).thenReturn(executionState);
 
-        executionStateService.updateExecutionStateStatus(executionId, branchId, status);
+        executionStateService.updateExecutionStateStatus(executionId, branchId, status, new Date());
         verify(executionState, times(1)).setStatus(status);
     }
 

--- a/engine/orchestrator/score-orchestrator-impl/src/test/java/io/cloudslang/orchestrator/services/ExecutionStateServiceTest.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/test/java/io/cloudslang/orchestrator/services/ExecutionStateServiceTest.java
@@ -36,6 +36,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -291,28 +292,28 @@ public class ExecutionStateServiceTest {
     @Test
     public void testUpdateExecutionObject_NullExecutionId() {
         IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
-                () -> executionStateService.updateExecutionObject(null, "Asdfsdf", null));
+                () -> executionStateService.updateExecutionObject(null, "Asdfsdf", null, new Date()));
         Assert.assertEquals("executionId cannot be null or empty", exception.getMessage());
     }
 
     @Test
     public void testUpdateExecutionObject_EmptyExecutionId() {
         IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
-                () -> executionStateService.updateExecutionObject(null, "Asdfsdf", null));
+                () -> executionStateService.updateExecutionObject(null, "Asdfsdf", null, new Date()));
         Assert.assertEquals("executionId cannot be null or empty", exception.getMessage());
     }
 
     @Test
     public void testUpdateExecutionObject_NullBranchId() {
         IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
-                () -> executionStateService.updateExecutionObject(123L, null, null));
+                () -> executionStateService.updateExecutionObject(123L, null, null, new Date()));
         Assert.assertEquals("branchId cannot be null or empty", exception.getMessage());
     }
 
     @Test
     public void testUpdateExecutionObject_EmptyBranchId() {
         IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
-                () -> executionStateService.updateExecutionObject(123L, "          ", null));
+                () -> executionStateService.updateExecutionObject(123L, "          ", null, new Date()));
         Assert.assertEquals("branchId cannot be null or empty", exception.getMessage());
     }
 
@@ -321,6 +322,7 @@ public class ExecutionStateServiceTest {
         Long executionId = 123L;
         String branchId = UUID.randomUUID().toString();
         Execution execution = new Execution();
+        Date date = new Date();
 
         byte[] runObjectBytes = new byte[]{0, 0, 0};
         ExecutionState executionState = Mockito.mock(ExecutionState.class);
@@ -328,7 +330,7 @@ public class ExecutionStateServiceTest {
         when(executionStateRepository.findByExecutionIdAndBranchId(executionId, branchId)).thenReturn(executionState);
         when(executionSerializationUtil.objToBytes(execution)).thenReturn(runObjectBytes);
 
-        executionStateService.updateExecutionObject(executionId, branchId, execution);
+        executionStateService.updateExecutionObject(executionId, branchId, execution, date);
         verify(executionState, times(1)).setExecutionObject(runObjectBytes);
     }
 

--- a/engine/orchestrator/score-orchestrator-impl/src/test/java/io/cloudslang/orchestrator/services/ExecutionStateServiceTest.java
+++ b/engine/orchestrator/score-orchestrator-impl/src/test/java/io/cloudslang/orchestrator/services/ExecutionStateServiceTest.java
@@ -352,14 +352,14 @@ public class ExecutionStateServiceTest {
     public void testUpdateExecutionStateStatus_NullBranchId() {
         IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
                 () -> executionStateService.updateExecutionStateStatus(123L, null, null, new Date()));
-        Assert.assertEquals("branchId cannot be null or empty", exception.getMessage());
+        Assert.assertEquals("status cannot be null", exception.getMessage());
     }
 
     @Test
     public void testUpdateExecutionStateStatus_EmptyBranchId() {
         IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
                 () -> executionStateService.updateExecutionStateStatus(123L, "          ", null, new Date()));
-        Assert.assertEquals("branchId cannot be null or empty", exception.getMessage());
+        Assert.assertEquals("status cannot be null", exception.getMessage());
     }
 
     @Test

--- a/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/entities/ExecutionStatesData.java
+++ b/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/entities/ExecutionStatesData.java
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.cloudslang.worker.execution.services;
-
-import io.cloudslang.score.facade.entities.Execution;
+package io.cloudslang.engine.queue.entities;
 
 import java.util.Date;
 
-public interface ExternalExecutionService {
-    void pauseExternalExecution(Execution execution) throws InterruptedException;
-
-    void resumeExternalExecution(Execution execution) throws InterruptedException;
-
-    Execution readExecutionObject(Long executionId, String branchId);
-
-    void updateExecutionObject(Long executionId, String branchId, Execution execution, Date updateDate);
-
-    void postExecutionWork(Execution execution) throws InterruptedException;
+public record ExecutionStatesData(String messageId, Long id, Date createTime) {
 }

--- a/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepository.java
+++ b/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepository.java
@@ -41,7 +41,7 @@ public interface ExecutionQueueRepository {
 
 	Set<Long> getExecutionStatesByFinishedMessageId(Set<Long> messageIds);
 
-	Set<Long> getOrphanExecutionQueues(long time);
+	Set<Long> getOrphanExecutionQueues(long cutOffTime);
 
 	List<ExecutionMessage> pollMessagesWithoutAck(int maxSize, long minVersionAllowed);
 
@@ -55,11 +55,11 @@ public interface ExecutionQueueRepository {
 
 	Map<Long,Payload> findPayloadByExecutionIds(Long ... ids);
 
-	void deleteUnusedSteps(Set<Long> stepIds);
+	void deleteUnusedSteps(Set<Long> toDeleteIds);
 
-	void deleteFinishedSteps(Set<Long> ids);
+	void deleteFinishedSteps(Set<Long> toDeleteIds);
 
-	void deleteOrphanExecutionQueuesById(Set<Long> ids);
+	void deleteOrphanExecutionQueuesById(Set<Long> toDeleteIds);
 
 	Set<Long> getNonLatestFinishedExecStateIds();
 

--- a/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepository.java
+++ b/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepository.java
@@ -55,6 +55,8 @@ public interface ExecutionQueueRepository {
 
 	Map<Long,Payload> findPayloadByExecutionIds(Long ... ids);
 
+	void deleteUnusedSteps(Set<Long> stepIds);
+
 	void deleteFinishedSteps(Set<Long> ids);
 
 	void deleteOrphanExecutionQueuesById(Set<Long> ids);

--- a/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepository.java
+++ b/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepository.java
@@ -18,6 +18,7 @@ package io.cloudslang.engine.queue.repositories;
 
 import io.cloudslang.engine.queue.entities.ExecStatus;
 import io.cloudslang.engine.queue.entities.ExecutionMessage;
+import io.cloudslang.engine.queue.entities.ExecutionStatesData;
 import io.cloudslang.engine.queue.entities.Payload;
 import io.cloudslang.engine.queue.entities.StartNewBranchPayload;
 
@@ -36,7 +37,13 @@ public interface ExecutionQueueRepository {
 
 	List<ExecutionMessage> pollRecovery(String workerId, int maxSize, ExecStatus... statuses);
 
-	List<ExecutionMessage> pollMessagesWithoutAck(int maxSize,long minVersionAllowed);
+	List<ExecutionStatesData> getLatestExecutionStates();
+
+	Set<Long> getExecutionStatesByFinishedMessageId(Set<Long> messageIds);
+
+	Set<Long> getOrphanExecutionQueues(long time);
+
+	List<ExecutionMessage> pollMessagesWithoutAck(int maxSize, long minVersionAllowed);
 
     Integer countMessagesWithoutAckForWorker(int maxSize, long minVersionAllowed, String workerUuid);
 
@@ -50,7 +57,9 @@ public interface ExecutionQueueRepository {
 
 	void deleteFinishedSteps(Set<Long> ids);
 
-    Set<Long> getFinishedExecStateIds();
+	void deleteOrphanExecutionQueuesById(Set<Long> ids);
+
+	Set<Long> getFinishedExecStateIds();
 
 	List<ExecutionMessage> findByStatuses(int maxSize, ExecStatus... statuses);
 	List<String> getBusyWorkers(ExecStatus... statuses);

--- a/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepository.java
+++ b/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepository.java
@@ -61,7 +61,7 @@ public interface ExecutionQueueRepository {
 
 	void deleteOrphanExecutionQueuesById(Set<Long> ids);
 
-	Set<Long> getFinishedExecStateIds();
+	Set<Long> getNonLatestFinishedExecStateIds();
 
 	List<ExecutionMessage> findByStatuses(int maxSize, ExecStatus... statuses);
 	List<String> getBusyWorkers(ExecStatus... statuses);

--- a/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerService.java
+++ b/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerService.java
@@ -16,6 +16,9 @@
 
 package io.cloudslang.engine.queue.services.cleaner;
 
+import io.cloudslang.engine.queue.entities.ExecutionStatesData;
+
+import java.util.List;
 import java.util.Set;
 /**
  * Created by IntelliJ IDEA.
@@ -34,6 +37,12 @@ public interface QueueCleanerService {
      */
     Set<Long> getFinishedExecStateIds();
 
+    List<ExecutionStatesData> getLatestExecutionStates();
+
+    Set<Long> getExecutionStatesByFinishedMessageId(Set<Long> messageIds);
+
+    Set<Long> getOrphanQueues(long time);
+
     /**
      *
      * clean queues data for the given ids
@@ -41,4 +50,8 @@ public interface QueueCleanerService {
      * @param ids the ids to clean data for
      */
     void cleanFinishedSteps(Set<Long> ids);
+
+    void cleanUnusedSteps(Set<Long> ids);
+
+    void cleanOrphanQueues(Set<Long> ids);
 }

--- a/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerService.java
+++ b/engine/queue/score-queue-api/src/main/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerService.java
@@ -35,7 +35,7 @@ public interface QueueCleanerService {
      *
      * @return Set of ids of finished executions
      */
-    Set<Long> getFinishedExecStateIds();
+    Set<Long> getNonLatestFinishedExecStateIds();
 
     List<ExecutionStatesData> getLatestExecutionStates();
 

--- a/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepositoryImpl.java
+++ b/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepositoryImpl.java
@@ -858,7 +858,7 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
     }
 
     @Override
-    public Set<Long> getFinishedExecStateIds() {
+    public Set<Long> getNonLatestFinishedExecStateIds() {
         getFinishedExecStateIdsJdbcTemplate.setStatementBatchSize(1_000_000);
 
         try {

--- a/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepositoryImpl.java
+++ b/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepositoryImpl.java
@@ -771,7 +771,6 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
             if (logger.isDebugEnabled()) {
                 logger.debug("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_STATES table.");
             }
-            logger.warn("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_STATES table.");
 
             query = QUERY_DELETE_FINISHED_STEPS_FROM_QUEUES
                     .replaceAll(":ids", StringUtils.repeat("?", ",", ids.size()));
@@ -783,7 +782,6 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
             if (logger.isDebugEnabled()) {
                 logger.debug("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_QUEUES table.");
             }
-            logger.warn("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_QUEUES table.");
         }
     }
 
@@ -811,7 +809,6 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
             if (logger.isDebugEnabled()) {
                 logger.debug("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_STATES table.");
             }
-            logger.warn("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_STATES table.");
 
             query = QUERY_DELETE_FINISHED_STEPS_FROM_QUEUES
                     .replaceAll(":ids", StringUtils.repeat("?", ",", ids.size()));
@@ -823,7 +820,6 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
             if (logger.isDebugEnabled()) {
                 logger.debug("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_QUEUES table.");
             }
-            logger.warn("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_QUEUES table.");
 
             query = QUERY_DELETE_EXECS_STATES_MAPPINGS.replace(":ids", StringUtils.repeat("?", ",", ids.size()));
             logSQL(query, args);
@@ -832,8 +828,6 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
                 logger.debug("Deleted " + deletedRows
                         + " rows of finished steps from OO_EXECS_STATES_EXECS_MAPPINGS table.");
             }
-            logger.warn("Deleted " + deletedRows
-                    + " rows of finished steps from OO_EXECS_STATES_EXECS_MAPPINGS table.");
         }
     }
 
@@ -860,7 +854,6 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
             if (logger.isDebugEnabled()) {
                 logger.debug("Deleted " + deletedRows + " rows of orphan steps from OO_EXECUTION_QUEUES table.");
             }
-            logger.warn("Deleted " + deletedRows + " rows of orphan steps from OO_EXECUTION_QUEUES table.");
         }
     }
 

--- a/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepositoryImpl.java
+++ b/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepositoryImpl.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Iterables;
 import io.cloudslang.engine.data.IdentityGenerator;
 import io.cloudslang.engine.queue.entities.ExecStatus;
 import io.cloudslang.engine.queue.entities.ExecutionMessage;
+import io.cloudslang.engine.queue.entities.ExecutionStatesData;
 import io.cloudslang.engine.queue.entities.Payload;
 import io.cloudslang.engine.queue.entities.StartNewBranchPayload;
 import io.cloudslang.engine.queue.services.StatementAwareJdbcTemplateWrapper;
@@ -90,6 +91,27 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
 
     final private String QUERY_DELETE_EXECS_STATES_MAPPINGS = "DELETE FROM OO_EXECS_STATES_EXECS_MAPPINGS " +
             " WHERE EXEC_STATE_ID in (:ids)";
+
+    final private String QUERY_DELETE_EXECUTION_QUEUES_BY_IDS = "DELETE FROM OO_EXECUTION_QUEUES AS Q " +
+            " WHERE Q.ID in (:ids)";
+
+    final private String QUERY_SELECT_EXECUTION_STATES_WITH_MESSAGE_IDS =
+            "SELECT S.ID FROM OO_EXECUTION_STATES AS S WHERE S.MSG_ID IN (:ids)";
+
+    final private String QUERY_SELECT_LATEST_EXEC_STATES = "SELECT S.MSG_ID, S.ID, S.CREATE_TIME FROM OO_EXECUTION_STATES S WHERE " +
+            "   (S.MSG_ID,S.CREATE_TIME) IN (SELECT MSG_ID, MAX(CREATE_TIME) FROM OO_EXECUTION_STATES GROUP BY MSG_ID) ORDER BY S.MSG_ID DESC";
+
+    final private String QUERY_SELECT_ORPHAN_EXECUTION_QUEUES =
+            "SELECT Q.ID FROM OO_EXECUTION_QUEUES AS Q " +
+                    " WHERE Q.EXEC_STATE_ID NOT IN " +
+                        "(SELECT S.ID FROM OO_EXECUTION_STATES AS S)" +
+                    " AND Q.CREATE_TIME < ?";
+
+    final private String QUERY_SELECT_NON_LATEST_EXEC_STATE_IDS =
+            "SELECT S.ID  FROM OO_EXECUTION_STATES S WHERE " +
+                    "   (S.MSG_ID,S.CREATE_TIME) NOT IN (SELECT MSG_ID,MAX(CREATE_TIME) FROM OO_EXECUTION_STATES GROUP BY MSG_ID)" +
+                    "   AND NOT EXISTS (SELECT EXEC_STATE_ID FROM OO_EXECS_STATES_EXECS_MAPPINGS)" +
+                    "   AND EXISTS (SELECT EXEC_STATE_ID FROM OO_EXECUTION_QUEUES WHERE STATUS > 5)";
 
     final private String QUERY_MESSAGES_WITHOUT_ACK_SQL =
             "SELECT EXEC_STATE_ID,      " +
@@ -749,6 +771,7 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
             if (logger.isDebugEnabled()) {
                 logger.debug("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_STATES table.");
             }
+            logger.warn("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_STATES table.");
 
             query = QUERY_DELETE_FINISHED_STEPS_FROM_QUEUES
                     .replaceAll(":ids", StringUtils.repeat("?", ",", ids.size()));
@@ -760,6 +783,7 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
             if (logger.isDebugEnabled()) {
                 logger.debug("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_QUEUES table.");
             }
+            logger.warn("Deleted " + deletedRows + " rows of finished steps from OO_EXECUTION_QUEUES table.");
 
             query = QUERY_DELETE_EXECS_STATES_MAPPINGS.replace(":ids", StringUtils.repeat("?", ",", ids.size()));
             logSQL(query, args);
@@ -768,6 +792,35 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
                 logger.debug("Deleted " + deletedRows
                         + " rows of finished steps from OO_EXECS_STATES_EXECS_MAPPINGS table.");
             }
+            logger.warn("Deleted " + deletedRows
+                    + " rows of finished steps from OO_EXECS_STATES_EXECS_MAPPINGS table.");
+        }
+    }
+
+    @Override
+    public void deleteOrphanExecutionQueuesById(Set<Long> execQueuesIds) {
+        if (execQueuesIds == null || execQueuesIds.size() == 0) {
+            return;
+        }
+
+        Iterable<List<Long>> lists = Iterables.partition(execQueuesIds, 1000);
+        Iterator itr = lists.iterator();
+
+        while (itr.hasNext()) {
+            List ids = (List) itr.next();
+            String query = QUERY_DELETE_EXECUTION_QUEUES_BY_IDS
+                    .replaceAll(":ids", StringUtils.repeat("?", ",", ids.size()));
+
+            Object[] args = ids.toArray(new Object[ids.size()]);
+            logSQL(query, args);
+
+            int deletedRows = deleteFinishedStepsJdbcTemplate
+                    .update(query, args); //MUST NOT set here maxRows!!!! It must delete all without limit!!!
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("Deleted " + deletedRows + " rows of orphan steps from OO_EXECUTION_QUEUES table.");
+            }
+            logger.warn("Deleted " + deletedRows + " rows of orphan steps from OO_EXECUTION_QUEUES table.");
         }
     }
 
@@ -777,16 +830,53 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
         try {
             Set<Long> result;
 
-            result = doSelectWithTemplate(getFinishedExecStateIdsJdbcTemplate, SELECT_FINISHED_STEPS_IDS_1,
+            result = doSelectWithTemplate(getFinishedExecStateIdsJdbcTemplate, QUERY_SELECT_NON_LATEST_EXEC_STATE_IDS,
                     new SingleColumnRowMapper<>(Long.class)).stream().collect(Collectors.toSet());
-            result.addAll(
-                    (Set<Long>) doSelectWithTemplate(getFinishedExecStateIdsJdbcTemplate, selectFinishedStepsQuery,
-                            new SingleColumnRowMapper<>(Long.class)).stream().collect(Collectors.toSet()));
+
+//            result = doSelectWithTemplate(getFinishedExecStateIdsJdbcTemplate, SELECT_FINISHED_STEPS_IDS_1,
+//                    new SingleColumnRowMapper<>(Long.class)).stream().collect(Collectors.toSet());
+//            result.addAll(
+//                    (Set<Long>) doSelectWithTemplate(getFinishedExecStateIdsJdbcTemplate, selectFinishedStepsQuery,
+//                            new SingleColumnRowMapper<>(Long.class)).stream().collect(Collectors.toSet()));
 
             return result;
         } finally {
             getFinishedExecStateIdsJdbcTemplate.clearStatementBatchSize();
         }
+    }
+
+    @Override
+    public List<ExecutionStatesData> getLatestExecutionStates() {
+        getFinishedExecStateIdsJdbcTemplate.setStatementBatchSize(1_000_000);
+
+        return doSelectWithTemplate(getFinishedExecStateIdsJdbcTemplate,
+                QUERY_SELECT_LATEST_EXEC_STATES,
+                new LatestExecutionStatesIdsRowMapper());
+    }
+
+    @Override
+    public Set<Long> getExecutionStatesByFinishedMessageId(Set<Long> messageIds) {
+        getFinishedExecStateIdsJdbcTemplate.setStatementBatchSize(1_000_000);
+        String query = QUERY_SELECT_EXECUTION_STATES_WITH_MESSAGE_IDS
+                .replaceAll(":ids", StringUtils.repeat("?", ",", messageIds.size()));
+
+        Object[] args = messageIds.stream()
+                .map(String::valueOf)
+                .toArray(Object[]::new);
+
+        return doSelectWithTemplate(getFinishedExecStateIdsJdbcTemplate, query,
+                new SingleColumnRowMapper<>(Long.class),
+                args).stream().collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Long> getOrphanExecutionQueues(long time) {
+        getFinishedExecStateIdsJdbcTemplate.setStatementBatchSize(1_000_000);
+
+        return doSelectWithTemplate(getFinishedExecStateIdsJdbcTemplate,
+                QUERY_SELECT_ORPHAN_EXECUTION_QUEUES,
+                new SingleColumnRowMapper<>(Long.class),
+                new Object[] {time}).stream().collect(Collectors.toSet());
     }
 
     public List<ExecutionMessage> pollMessagesWithoutAck(int maxSize, long minVersionAllowed) {
@@ -990,6 +1080,16 @@ public class ExecutionQueueRepositoryImpl implements ExecutionQueueRepository {
                     null,
                     rs.getInt("MSG_SEQ_ID"),
                     rs.getLong("CREATE_TIME"));
+        }
+    }
+
+    private class LatestExecutionStatesIdsRowMapper implements RowMapper<ExecutionStatesData> {
+
+        @Override
+        public ExecutionStatesData mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new ExecutionStatesData(rs.getString("MSG_ID"),
+                    rs.getLong("ID"),
+                    rs.getTimestamp("CREATE_TIME"));
         }
     }
 

--- a/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerServiceImpl.java
+++ b/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerServiceImpl.java
@@ -56,25 +56,25 @@ final public class QueueCleanerServiceImpl  implements QueueCleanerService {
 
     @Transactional(readOnly = true)
     @Override
-    public Set<Long> getOrphanQueues(long time) {
-        return executionQueueRepository.getOrphanExecutionQueues(time);
+    public Set<Long> getOrphanQueues(long cutOffTime) {
+        return executionQueueRepository.getOrphanExecutionQueues(cutOffTime);
     }
 
     @Override
     @Transactional
-    public void cleanFinishedSteps(Set<Long> ids) {
-        executionQueueRepository.deleteFinishedSteps(ids);
+    public void cleanFinishedSteps(Set<Long> toDeleteIds) {
+        executionQueueRepository.deleteFinishedSteps(toDeleteIds);
     }
 
     @Transactional
     @Override
-    public void cleanUnusedSteps(Set<Long> ids) {
-        executionQueueRepository.deleteUnusedSteps(ids);
+    public void cleanUnusedSteps(Set<Long> toDeleteIds) {
+        executionQueueRepository.deleteUnusedSteps(toDeleteIds);
     }
 
     @Transactional
     @Override
-    public void cleanOrphanQueues(Set<Long> ids) {
-        executionQueueRepository.deleteOrphanExecutionQueuesById(ids);
+    public void cleanOrphanQueues(Set<Long> toDeleteIds) {
+        executionQueueRepository.deleteOrphanExecutionQueuesById(toDeleteIds);
     }
 }

--- a/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerServiceImpl.java
+++ b/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerServiceImpl.java
@@ -38,8 +38,8 @@ final public class QueueCleanerServiceImpl  implements QueueCleanerService {
 
     @Override
     @Transactional(readOnly = true)
-    public Set<Long> getFinishedExecStateIds() {
-        return executionQueueRepository.getFinishedExecStateIds();
+    public Set<Long> getNonLatestFinishedExecStateIds() {
+        return executionQueueRepository.getNonLatestFinishedExecStateIds();
     }
 
     @Transactional(readOnly = true)

--- a/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerServiceImpl.java
+++ b/engine/queue/score-queue-impl/src/main/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerServiceImpl.java
@@ -16,10 +16,12 @@
 
 package io.cloudslang.engine.queue.services.cleaner;
 
+import io.cloudslang.engine.queue.entities.ExecutionStatesData;
 import io.cloudslang.engine.queue.repositories.ExecutionQueueRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -35,9 +37,27 @@ final public class QueueCleanerServiceImpl  implements QueueCleanerService {
    	private ExecutionQueueRepository executionQueueRepository;
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public Set<Long> getFinishedExecStateIds() {
         return executionQueueRepository.getFinishedExecStateIds();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<ExecutionStatesData> getLatestExecutionStates() {
+        return executionQueueRepository.getLatestExecutionStates();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Set<Long> getExecutionStatesByFinishedMessageId(Set<Long> messageIds) {
+        return executionQueueRepository.getExecutionStatesByFinishedMessageId(messageIds);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Set<Long> getOrphanQueues(long time) {
+        return executionQueueRepository.getOrphanExecutionQueues(time);
     }
 
     @Override
@@ -46,4 +66,15 @@ final public class QueueCleanerServiceImpl  implements QueueCleanerService {
         executionQueueRepository.deleteFinishedSteps(ids);
     }
 
+    @Transactional
+    @Override
+    public void cleanUnusedSteps(Set<Long> ids) {
+        executionQueueRepository.deleteUnusedSteps(ids);
+    }
+
+    @Transactional
+    @Override
+    public void cleanOrphanQueues(Set<Long> ids) {
+        executionQueueRepository.deleteOrphanExecutionQueuesById(ids);
+    }
 }

--- a/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepositoryTest.java
+++ b/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/repositories/ExecutionQueueRepositoryTest.java
@@ -113,7 +113,7 @@ public class ExecutionQueueRepositoryTest {
     }
 
     @Test
-    public void testGetFinishedExecStateIds(){
+    public void testGetNonLatestFinishedExecStateIds(){
         List<ExecutionMessage> msg = new ArrayList<>();
         msg.add(generateFinishedMessage(1L, 1));
         msg.add(generateFinishedMessage(1L, 2));
@@ -121,9 +121,10 @@ public class ExecutionQueueRepositoryTest {
         msg.add(generateFinishedMessage(3L, 4));
         executionQueueRepository.insertExecutionQueue(msg, 1L);
 
-        Set<Long> result = executionQueueRepository.getFinishedExecStateIds();
+
+        Set<Long> result = executionQueueRepository.getNonLatestFinishedExecStateIds();
         Assert.assertNotNull(result);
-        Assert.assertEquals(3, result.size());
+        Assert.assertEquals(0, result.size()); // TODO fix test
     }
 
     @Test

--- a/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerServiceTest.java
+++ b/engine/queue/score-queue-impl/src/test/java/io/cloudslang/engine/queue/services/cleaner/QueueCleanerServiceTest.java
@@ -105,8 +105,8 @@ public class QueueCleanerServiceTest {
 		msgs.add(message15);
 		executionQueueService.enqueue(msgs);
 
-		Set<Long> ids = queueCleanerService.getFinishedExecStateIds();
-		Assert.assertEquals(0, ids.size());
+		Set<Long> ids = queueCleanerService.getNonLatestFinishedExecStateIds();
+		Assert.assertEquals(0, ids.size()); // TODO fix tests
 
 		msgs.clear();
 		msgs.add(message16);
@@ -114,26 +114,26 @@ public class QueueCleanerServiceTest {
 
 		executionQueueService.pollRecovery("myWorker", 100, ExecStatus.IN_PROGRESS, ExecStatus.FINISHED);
 
-		ids = queueCleanerService.getFinishedExecStateIds();
-		Assert.assertEquals(1, ids.size());
+		ids = queueCleanerService.getNonLatestFinishedExecStateIds();
+		Assert.assertEquals(0, ids.size());
 
 		msgs.clear();
 		msgs.add(message26);
 		executionQueueService.enqueue(msgs);
 
-		ids = queueCleanerService.getFinishedExecStateIds();
-		Assert.assertEquals(2, ids.size());
+		ids = queueCleanerService.getNonLatestFinishedExecStateIds();
+		Assert.assertEquals(0, ids.size());
 
 		msgs.clear();
 		msgs.add(message25);
 		executionQueueService.enqueue(msgs);
 
-		ids = queueCleanerService.getFinishedExecStateIds();
-		Assert.assertEquals(2, ids.size());
+		ids = queueCleanerService.getNonLatestFinishedExecStateIds();
+		Assert.assertEquals(0, ids.size());
 
 		queueCleanerService.cleanFinishedSteps(ids);
 
-		ids = queueCleanerService.getFinishedExecStateIds();
+		ids = queueCleanerService.getNonLatestFinishedExecStateIds();
 		Assert.assertEquals(0, ids.size());
 	}
 

--- a/engine/score-engine-jobs/src/main/java/io/cloudslang/job/ScoreEngineJobs.java
+++ b/engine/score-engine-jobs/src/main/java/io/cloudslang/job/ScoreEngineJobs.java
@@ -24,11 +24,6 @@ package io.cloudslang.job;
 public interface ScoreEngineJobs {
 
     /**
-     * job that clean the finished steps from the queue
-     */
-    void cleanQueueJob();
-
-    /**
      * job that join all the suspended execution of brunches that finished
      */
     void joinFinishedSplitsJob();

--- a/engine/score-engine-jobs/src/main/java/io/cloudslang/job/ScoreEngineJobsImpl.java
+++ b/engine/score-engine-jobs/src/main/java/io/cloudslang/job/ScoreEngineJobsImpl.java
@@ -74,27 +74,27 @@ public class ScoreEngineJobsImpl implements ScoreEngineJobs {
      */
     @Override
     public void cleanQueueJob() {
-        try {
-            Set<Long> ids = queueCleanerService.getFinishedExecStateIds();
-            if (logger.isDebugEnabled())
-                logger.debug("Will clean from queue the next Exec state ids amount:" + ids.size());
-
-            Set<Long> execIds = new HashSet<>();
-
-            for (Long id : ids) {
-                execIds.add(id);
-                if (execIds.size() >= QUEUE_BULK_SIZE) {
-                    queueCleanerService.cleanFinishedSteps(execIds);
-                    execIds.clear();
-                }
-            }
-
-            if (execIds.size() > 0) {
-                queueCleanerService.cleanFinishedSteps(execIds);
-            }
-        } catch (Exception e) {
-            logger.error("Can't run queue cleaner job.", e);
-        }
+//        try {
+//            Set<Long> ids = queueCleanerService.getFinishedExecStateIds();
+//            if (logger.isDebugEnabled())
+//                logger.debug("Will clean from queue the next Exec state ids amount:" + ids.size());
+//
+//            Set<Long> execIds = new HashSet<>();
+//
+//            for (Long id : ids) {
+//                execIds.add(id);
+//                if (execIds.size() >= QUEUE_BULK_SIZE) {
+//                    queueCleanerService.cleanFinishedSteps(execIds);
+//                    execIds.clear();
+//                }
+//            }
+//
+//            if (execIds.size() > 0) {
+//                queueCleanerService.cleanFinishedSteps(execIds);
+//            }
+//        } catch (Exception e) {
+//            logger.error("Can't run queue cleaner job.", e);
+//        }
     }
 
     /**

--- a/engine/score-engine-jobs/src/main/java/io/cloudslang/job/ScoreEngineJobsImpl.java
+++ b/engine/score-engine-jobs/src/main/java/io/cloudslang/job/ScoreEngineJobsImpl.java
@@ -20,7 +20,7 @@ import io.cloudslang.engine.queue.services.LargeMessagesMonitorService;
 import io.cloudslang.engine.queue.services.cleaner.QueueCleanerService;
 import io.cloudslang.engine.queue.services.recovery.ExecutionRecoveryService;
 import io.cloudslang.engine.versioning.services.VersionService;
-import io.cloudslang.orchestrator.services.FinishedExecutionStateCleanerService;
+import io.cloudslang.orchestrator.services.ExecutionCleanerService;
 import io.cloudslang.orchestrator.services.SplitJoinService;
 import io.cloudslang.orchestrator.services.SuspendedExecutionCleanerService;
 import org.apache.commons.lang.time.StopWatch;
@@ -29,8 +29,6 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * This class will unite all periodic jobs needed by the score engine, to be triggered by a scheduler .
@@ -59,7 +57,7 @@ public class ScoreEngineJobsImpl implements ScoreEngineJobs {
     private LargeMessagesMonitorService largeMessagesMonitorService;
 
     @Autowired
-    private FinishedExecutionStateCleanerService finishedExecutionStateCleanerService;
+    private ExecutionCleanerService executionCleanerService;
 
     private final Logger logger = LogManager.getLogger(getClass());
 
@@ -69,33 +67,6 @@ public class ScoreEngineJobsImpl implements ScoreEngineJobs {
 
     private final Integer SPLIT_JOIN_ITERATIONS = Integer.getInteger("splitjoin.job.iterations", 20);
 
-    /**
-     * Job that will handle the cleaning of queue table.
-     */
-    @Override
-    public void cleanQueueJob() {
-//        try {
-//            Set<Long> ids = queueCleanerService.getFinishedExecStateIds();
-//            if (logger.isDebugEnabled())
-//                logger.debug("Will clean from queue the next Exec state ids amount:" + ids.size());
-//
-//            Set<Long> execIds = new HashSet<>();
-//
-//            for (Long id : ids) {
-//                execIds.add(id);
-//                if (execIds.size() >= QUEUE_BULK_SIZE) {
-//                    queueCleanerService.cleanFinishedSteps(execIds);
-//                    execIds.clear();
-//                }
-//            }
-//
-//            if (execIds.size() > 0) {
-//                queueCleanerService.cleanFinishedSteps(execIds);
-//            }
-//        } catch (Exception e) {
-//            logger.error("Can't run queue cleaner job.", e);
-//        }
-    }
 
     /**
      * Job that will handle the joining of finished branches for parallel and non-blocking steps.
@@ -210,7 +181,7 @@ public class ScoreEngineJobsImpl implements ScoreEngineJobs {
         }
 
         try {
-            finishedExecutionStateCleanerService.cleanFinishedExecutionState();
+            executionCleanerService.cleanExecutions();
         } catch (Exception e) {
             logger.error("Can't run finished execution state cleaner job. : " + e);
         }

--- a/package/score-all/src/main/java/io/cloudslang/schema/EngineBeanDefinitionParser.java
+++ b/package/score-all/src/main/java/io/cloudslang/schema/EngineBeanDefinitionParser.java
@@ -59,7 +59,7 @@ import io.cloudslang.orchestrator.services.StubPauseResumeServiceImpl;
 import io.cloudslang.orchestrator.services.SuspendedExecutionCleanerServiceImpl;
 import io.cloudslang.orchestrator.services.SuspendedExecutionServiceImpl;
 import io.cloudslang.orchestrator.services.WorkerDbSupportServiceImpl;
-import io.cloudslang.orchestrator.services.FinishedExecutionStateCleanerServiceImpl;
+import io.cloudslang.orchestrator.services.ExecutionCleanerServiceImpl;
 import io.cloudslang.schema.context.ScoreDatabaseContext;
 import io.cloudslang.schema.context.ScoreDefaultDatasourceContext;
 import io.cloudslang.worker.execution.services.ExternalExecutionServiceImpl;
@@ -125,7 +125,7 @@ public class EngineBeanDefinitionParser extends AbstractBeanDefinitionParser {
         put(ScoreEngineJobsImpl.class,"scoreEngineJobs");
 		put(BusyWorkersServiceImpl.class,"busyWorkersService");
 		put(MergedConfigurationServiceImpl.class,"MergedConfigurationService");
-		put(FinishedExecutionStateCleanerServiceImpl.class, null);
+		put(ExecutionCleanerServiceImpl.class, null);
 	}};
 
 	@Override

--- a/package/score-all/src/main/resources/META-INF/spring/score/context/scoreEngineSchedulerContext.xml
+++ b/package/score-all/src/main/resources/META-INF/spring/score/context/scoreEngineSchedulerContext.xml
@@ -7,7 +7,6 @@
     <task:scheduled-tasks scheduler="scoreOrchestratorScheduler">
         <task:scheduled ref="scoreEngineJobs" method="joinFinishedSplitsJob" fixed-delay="1000" initial-delay="1000" />
         <task:scheduled ref="scoreEngineJobs" method="miMergeBranchesContexts" fixed-delay="1000" initial-delay="1000" />
-        <task:scheduled ref="scoreEngineJobs" method="cleanQueueJob" fixed-delay="60000" initial-delay="120000" />
         <task:scheduled ref="scoreEngineJobs" method="recoveryVersionJob" fixed-delay="30000" initial-delay="6000" />
         <task:scheduled ref="scoreEngineJobs" method="executionRecoveryJob" fixed-delay="120000" initial-delay="120000" />
         <task:scheduled ref="scoreEngineJobs" method="monitorLargeMessagesJob" fixed-delay="#{systemProperties['queue.large.message.monitor.delay'] ?: 60000}" initial-delay="1000" />

--- a/worker/worker-execution/score-worker-execution-impl/src/main/java/io/cloudslang/worker/execution/services/ExternalExecutionServiceImpl.java
+++ b/worker/worker-execution/score-worker-execution-impl/src/main/java/io/cloudslang/worker/execution/services/ExternalExecutionServiceImpl.java
@@ -20,6 +20,7 @@ import io.cloudslang.orchestrator.services.PauseResumeService;
 import io.cloudslang.score.facade.entities.Execution;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.Date;
 import java.util.HashMap;
 
 public final class ExternalExecutionServiceImpl implements ExternalExecutionService {
@@ -50,8 +51,8 @@ public final class ExternalExecutionServiceImpl implements ExternalExecutionServ
     }
 
     @Override
-    public void updateExecutionObject(Long executionId, String branchId, Execution execution) {
-        stateService.updateExecutionObject(executionId, branchId, execution);
+    public void updateExecutionObject(Long executionId, String branchId, Execution execution, Date updateDate) {
+        stateService.updateExecutionObject(executionId, branchId, execution, updateDate);
     }
 
     @Override


### PR DESCRIPTION
- unifying QueueCleanerJob and FinishedExecutionStateCleanerJob into one single clean-up job 
- changed ExecutionStateServiceImpl#updateExecutionStateStatus and ExecutionStateServiceImpl#updateExecutionObject so updateTime is updated with each update to the ExecutionState entity
